### PR TITLE
Restructure functions file

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,26 +1,45 @@
 <?php
-//* Start the engine
-include_once( get_template_directory() . '/lib/init.php' );
+/**
+ * Custom amendments for the theme.
+ *
+ * @package    Genesis_Sample\Custom
+ * @author     StudioPress
+ * @license    GPL2-0+
+ * @link       http://studiopress.com
+ */
 
-//* Child theme (do not remove)
-define( 'CHILD_THEME_NAME', 'Genesis Sample Theme' );
-define( 'CHILD_THEME_URL', 'http://www.studiopress.com/' );
-define( 'CHILD_THEME_VERSION', '2.0.1' );
+add_action( 'genesis_setup', 'genesis_sample_setup', 15 );
+/**
+ * Theme setup.
+ *
+ * Attach all of the site-wide functions to the correct hooks and filters. All
+ * the functions themselves are defined below this setup function.
+ *
+ * @since 2.1.0
+ */
+function genesis_sample_setup() {
+	define( 'CHILD_THEME_NAME', 'Genesis Sample Theme' );
+	define( 'CHILD_THEME_URL', 'http://www.studiopress.com/' );
+	define( 'CHILD_THEME_VERSION', '2.0.1' );
 
-//* Enqueue Lato Google font
-add_action( 'wp_enqueue_scripts', 'genesis_sample_google_fonts' );
-function genesis_sample_google_fonts() {
-	wp_enqueue_style( 'google-font-lato', '//fonts.googleapis.com/css?family=Lato:300,700', array(), CHILD_THEME_VERSION );
+	load_child_theme_textdomain( 'genesis-sample', get_stylesheet_directory() . '/languages' );
+
+	add_theme_support( 'html5' );
+	add_theme_support( 'genesis-responsive-viewport' );
+	add_theme_support( 'custom-background' );
+	add_theme_support( 'genesis-footer-widgets', 3 );
+
+	// add_editor_style( 'editor-style.css' );
+
+	add_action( 'wp_enqueue_scripts', 'genesis_sample_google_web_fonts' );
+
 }
 
-//* Add HTML5 markup structure
-add_theme_support( 'html5' );
-
-//* Add viewport meta tag for mobile browsers
-add_theme_support( 'genesis-responsive-viewport' );
-
-//* Add support for custom background
-add_theme_support( 'custom-background' );
-
-//* Add support for 3-column footer widgets
-add_theme_support( 'genesis-footer-widgets', 3 );
+/**
+ * Enqueue Google Web Fonts.
+ *
+ * @since Unknown
+ */
+function genesis_sample_google_web_fonts() {
+	wp_enqueue_style( 'genesis-sample-google-web-fonts', '//fonts.googleapis.com/css?family=Lato:300,700', array(), CHILD_THEME_VERSION );
+}


### PR DESCRIPTION
There's a lot of Genesis developers who follow the approach in the PR - hooking all of the setup into a `*_setup()` function attached to the `genesis_setup` hook at priority 15. It really works well as Genesis has no problems with this being done.

The function permits commented-out lines of code (I've left one in as an example), which can indicate where custom-header, editor-styles, image sizes, sidebar registrations, and other such non-function setup can also be defined, along with actions and filters.
