### PR TITLE
Add 'tel' and 'url' types for HTML5 Gravity Forms styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -786,7 +786,9 @@ Plugins
 --------------------------------------------- */
 
 div.gform_wrapper input[type="email"],
+div.gform_wrapper input[type="tel"],
 div.gform_wrapper input[type="text"],
+div.gform_wrapper input[type="url"],
 div.gform_wrapper textarea,
 div.gform_wrapper .ginput_complex label {
 	font-size: 16px;


### PR DESCRIPTION
Currently if you turn on 'Output HTML5 under Forms > Settings in Gravity Forms with the Genesis Sample theme active, the padding for the Gravity Forms 'tel' and 'url' input types does not match the styling of the other Gravity Form inputs.

This tweak makes them all have consistent padding.

Signed-off-by: Nick Davis nick@nickdavis.co
