### PR TITLE
PHPCS: Add XSD to validate phpcs.xml.dist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"php": "^5.6 || ^7",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
 		"phpcompatibility/phpcompatibility-wp": "^2",
-		"squizlabs/php_codesniffer": "^3.2",
+		"squizlabs/php_codesniffer": "^3.3.2",
 		"wp-coding-standards/wpcs": "^1.1"
 	},
 	"config": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<ruleset name="Genesis-Sample">
+<ruleset name="Genesis-Sample"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
 	<description>Custom ruleset for Genesis Sample.</description>
 
 	<!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
@@ -32,7 +35,9 @@
 	<rule ref="WordPress-Extra"/><!-- Includes WordPress-Core -->
 	<rule ref="WordPress-Docs"/>
 
-<exclude name="Squiz.PHP.CommentedOutCode.Found"/>
+	<rule ref="Squiz.PHP.CommentedOutCode.Found">
+		<severity>0</severity>
+	</rule>
 
 	<!-- Allow theme-specific exceptions to WordPress filename rules. -->
 	<rule ref="WordPress.Files.FileName">


### PR DESCRIPTION
Requires PHP_CodeSniffer 3.3.2 which contains the XSD that is updated with the new array element format.

Also, fix the incorrect `exclude`, which the XSD validation highlighted.