### PR TITLE
Add Gutenberg support via a hook

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -51,8 +51,15 @@ require_once get_stylesheet_directory() . '/lib/woocommerce/woocommerce-output.p
 // Adds the Genesis Connect WooCommerce notice.
 require_once get_stylesheet_directory() . '/lib/woocommerce/woocommerce-notice.php';
 
-// Adds Gutenberg support.
-require_once get_stylesheet_directory() . '/lib/gutenberg/init.php';
+add_action( 'after_setup_theme', 'genesis_child_gutenberg_support' );
+/**
+ * Adds Gutenberg opt-in features and styling.
+ *
+ * @since 2.7.0
+ */
+function genesis_child_gutenberg_support() {
+	require_once get_stylesheet_directory() . '/lib/gutenberg/init.php';
+}
 
 add_action( 'wp_enqueue_scripts', 'genesis_sample_enqueue_scripts_styles' );
 /**


### PR DESCRIPTION
This allows it to be removed from a plugin or from Genesis.

See #139.