### PR TITLE
Configify the sample theme

### DIFF
--- a/config/accessibility.php
+++ b/config/accessibility.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Genesis Sample child theme.
+ *
+ * @author  StudioPress
+ * @license GPL-2.0-or-later
+ * @link    https://my.studiopress.com/themes/genesis-sample/
+ */
+
+/**
+ * Genesis Accessibility features to support.
+ */
+return array(
+	'404-page',
+	'drop-down-menu',
+	'headings',
+	'search-form',
+	'skip-links',
+);

--- a/config/custom-logo.php
+++ b/config/custom-logo.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Genesis Sample child theme.
+ *
+ * @author  StudioPress
+ * @license GPL-2.0-or-later
+ * @link    https://my.studiopress.com/themes/genesis-sample/
+ */
+
+/**
+ * Custom Logo configuration.
+ */
+return array(
+	'height'      => 120,
+	'width'       => 700,
+	'flex-height' => true,
+	'flex-width'  => true,
+);

--- a/config/editor-color-palette.php
+++ b/config/editor-color-palette.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Genesis Sample child theme.
+ *
+ * @author  StudioPress
+ * @license GPL-2.0-or-later
+ * @link    https://my.studiopress.com/themes/genesis-sample/
+ */
+
+/**
+ * Editor font sizes config.
+ */
+return array(
+	array(
+		'name'      => __( 'Small', 'genesis-sample' ),
+		'shortName' => __( 'S', 'genesis-sample' ),
+		'size'      => 12,
+		'slug'      => 'small',
+	),
+	array(
+		'name'      => __( 'Normal', 'genesis-sample' ),
+		'shortName' => __( 'M', 'genesis-sample' ),
+		'size'      => 16,
+		'slug'      => 'normal',
+	),
+	array(
+		'name'      => __( 'Large', 'genesis-sample' ),
+		'shortName' => __( 'L', 'genesis-sample' ),
+		'size'      => 20,
+		'slug'      => 'large',
+	),
+	array(
+		'name'      => __( 'Larger', 'genesis-sample' ),
+		'shortName' => __( 'XL', 'genesis-sample' ),
+		'size'      => 24,
+		'slug'      => 'larger',
+	),
+)

--- a/config/editor-font-sizes.php
+++ b/config/editor-font-sizes.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Genesis Sample child theme.
+ *
+ * @author  StudioPress
+ * @license GPL-2.0-or-later
+ * @link    https://my.studiopress.com/themes/genesis-sample/
+ */
+
+/**
+ * Editor font sizes config.
+ */
+return array(
+	array(
+		'name'      => __( 'Small', 'genesis-sample' ),
+		'shortName' => __( 'S', 'genesis-sample' ),
+		'size'      => 12,
+		'slug'      => 'small',
+	),
+	array(
+		'name'      => __( 'Normal', 'genesis-sample' ),
+		'shortName' => __( 'M', 'genesis-sample' ),
+		'size'      => 16,
+		'slug'      => 'normal',
+	),
+	array(
+		'name'      => __( 'Large', 'genesis-sample' ),
+		'shortName' => __( 'L', 'genesis-sample' ),
+		'size'      => 20,
+		'slug'      => 'large',
+	),
+	array(
+		'name'      => __( 'Larger', 'genesis-sample' ),
+		'shortName' => __( 'XL', 'genesis-sample' ),
+		'size'      => 24,
+		'slug'      => 'larger',
+	),
+)

--- a/config/html5.php
+++ b/config/html5.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Genesis Sample child theme.
+ *
+ * @author  StudioPress
+ * @license GPL-2.0-or-later
+ * @link    https://my.studiopress.com/themes/genesis-sample/
+ */
+
+/**
+ * Elements to output as html5.
+ */
+return array(
+	'404-page',
+	'drop-down-menu',
+	'headings',
+	'search-form',
+	'skip-links',
+);

--- a/config/layouts.php
+++ b/config/layouts.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Genesis Sample child theme.
+ *
+ * @author  StudioPress
+ * @license GPL-2.0-or-later
+ * @link    https://my.studiopress.com/themes/genesis-sample/
+ */
+
+// Pull default layouts from Genesis
+$genesis_config = genesis_get_config( 'layouts', 'secondary' );
+
+/**
+ * The Layouts config. Sets the default layouts for use by Genesis.
+ *
+ * @since 2.8.0
+ */
+return array(
+	'content-sidebar'    => $config['content-sidebar'],
+	'sidebar-content'    => $config['sidebar-content'],
+	'full-width-content' => $config['full-width-content'],
+);

--- a/config/menus.php
+++ b/config/menus.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Genesis Sample child theme.
+ *
+ * @author  StudioPress
+ * @license GPL-2.0-or-later
+ * @link    https://my.studiopress.com/themes/genesis-sample/
+ */
+
+/**
+ * Supported Genesis navigation menus.
+ */
+return array(
+	'primary'   => __( 'Header Menu', 'genesis-sample' ),
+	'secondary' => __( 'Footer Menu', 'genesis-sample' ),
+);

--- a/functions.php
+++ b/functions.php
@@ -128,53 +128,19 @@ function genesis_sample_responsive_menu_settings() {
 }
 
 // Adds support for HTML5 markup structure.
-add_theme_support(
-	'html5',
-	array(
-		'caption',
-		'comment-form',
-		'comment-list',
-		'gallery',
-		'search-form',
-	)
-);
+add_theme_support( 'html5', genesis_get_config( 'html5' ) );
 
 // Adds support for accessibility.
-add_theme_support(
-	'genesis-accessibility',
-	array(
-		'404-page',
-		'drop-down-menu',
-		'headings',
-		'search-form',
-		'skip-links',
-	)
-);
+add_theme_support( 'genesis-accessibility', genesis_get_config( 'accessibility' ) );
 
 // Adds viewport meta tag for mobile browsers.
-add_theme_support(
-	'genesis-responsive-viewport'
-);
+add_theme_support( 'genesis-responsive-viewport' );
 
 // Adds custom logo in Customizer > Site Identity.
-add_theme_support(
-	'custom-logo',
-	array(
-		'height'      => 120,
-		'width'       => 700,
-		'flex-height' => true,
-		'flex-width'  => true,
-	)
-);
+add_theme_support( 'custom-logo', genesis_get_config( 'custom-logo' ) );
 
 // Renames primary and secondary navigation menus.
-add_theme_support(
-	'genesis-menus',
-	array(
-		'primary'   => __( 'Header Menu', 'genesis-sample' ),
-		'secondary' => __( 'Footer Menu', 'genesis-sample' ),
-	)
-);
+add_theme_support( 'genesis-menus', genesis_get_config( 'menus' ) );
 
 // Adds image sizes.
 add_image_size( 'sidebar-featured', 75, 75, true );

--- a/lib/gutenberg/init.php
+++ b/lib/gutenberg/init.php
@@ -59,54 +59,13 @@ add_theme_support( 'responsive-embeds' );
 // Adds support for editor font sizes.
 add_theme_support(
 	'editor-font-sizes',
-	array(
-		array(
-			'name'      => __( 'Small', 'genesis-sample' ),
-			'shortName' => __( 'S', 'genesis-sample' ),
-			'size'      => 12,
-			'slug'      => 'small',
-		),
-		array(
-			'name'      => __( 'Normal', 'genesis-sample' ),
-			'shortName' => __( 'M', 'genesis-sample' ),
-			'size'      => 16,
-			'slug'      => 'normal',
-		),
-		array(
-			'name'      => __( 'Large', 'genesis-sample' ),
-			'shortName' => __( 'L', 'genesis-sample' ),
-			'size'      => 20,
-			'slug'      => 'large',
-		),
-		array(
-			'name'      => __( 'Larger', 'genesis-sample' ),
-			'shortName' => __( 'XL', 'genesis-sample' ),
-			'size'      => 24,
-			'slug'      => 'larger',
-		),
-	)
+	genesis_get_config( 'editor-font-sizes' )
 );
 
 // Adds support for editor color palette.
 add_theme_support(
 	'editor-color-palette',
-	array(
-		array(
-			'name'  => __( 'Light gray', 'genesis-sample' ),
-			'slug'  => 'light-gray',
-			'color' => '#f5f5f5',
-		),
-		array(
-			'name'  => __( 'Medium gray', 'genesis-sample' ),
-			'slug'  => 'medium-gray',
-			'color' => '#999',
-		),
-		array(
-			'name'  => __( 'Dark gray', 'genesis-sample' ),
-			'slug'  => 'dark-gray',
-			'color' => '#333',
-		),
-	)
+	genesis_get_config( 'editor-color-palette' )
 );
 
 add_action( 'after_setup_theme', 'genesis_sample_content_width', 0 );


### PR DESCRIPTION
Once Genesis 2.8 beta is live, we should also have a beta for the sample theme that uses the config getter that Genesis 2.8 includes to clean up and slim down the functions.php.