### PR TITLE
Add block-specific body classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Genesis Sample Theme Changelog
 
 ## [Unreleased]
-* 
+* New: Add `has-no-blocks` body class if singular post/page contains no blocks.
+* New: Add `first-block-[block-name]` body class. Helps remove top padding when blocks such as the Cover block are first on the page.
+* New: Add `first-block-align-[alignment]` body class. Helps adjust styles if the first block is full-width.
 
 ## [2.7.0] - 2018-12-12
 * New: Add Gutenberg opt-in feature support (wide blocks, fonts, colors, editor and block styling).

--- a/lib/gutenberg/init.php
+++ b/lib/gutenberg/init.php
@@ -52,6 +52,8 @@ add_filter( 'body_class', 'genesis_sample_blocks_body_classes' );
  * - `first-block-[block-name]` to allow changes based on the first block (such as removing padding above a Cover block).
  * - `first-block-align-[alignment]` to allow styling adjustment if the first block is wide or full-width.
  *
+ * @since 2.8.0
+ *
  * @param array $classes The original classes.
  * @return array The modified classes.
  */

--- a/lib/gutenberg/init.php
+++ b/lib/gutenberg/init.php
@@ -44,6 +44,43 @@ function genesis_sample_block_editor_styles() {
 
 }
 
+add_filter( 'body_class', 'genesis_sample_blocks_body_classes' );
+/**
+ * Adds body classes to help with block styling.
+ *
+ * - `has-no-blocks` if content contains no blocks.
+ * - `first-block-[block-name]` to allow changes based on the first block (such as removing padding above a Cover block).
+ * - `first-block-align-[alignment]` to allow styling adjustment if the first block is wide or full-width.
+ *
+ * @param array $classes The original classes.
+ * @return array The modified classes.
+ */
+function genesis_sample_blocks_body_classes( $classes ) {
+
+	if ( ! is_singular() || ! function_exists( 'has_blocks' ) || ! function_exists( 'parse_blocks') ) {
+		return $classes;
+	}
+
+	if ( ! has_blocks() ) {
+		$classes[] = 'has-no-blocks';
+		return $classes;
+	}
+
+	$post_object = get_post( get_the_ID() );
+	$blocks      = (array) parse_blocks( $post_object->post_content );
+
+	if ( isset( $blocks[0]['blockName'] ) ) {
+		$classes[] = 'first-block-' . str_replace( '/', '-', $blocks[0]['blockName'] );
+	}
+
+	if ( isset( $blocks[0]['attrs']['align'] ) ) {
+		$classes[] = 'first-block-align-' . $blocks[0]['attrs']['align'];
+	}
+
+	return $classes;
+
+}
+
 // Add support for editor styles.
 add_theme_support( 'editor-styles' );
 


### PR DESCRIPTION
All classes apply to singular posts/pages only.

- `has-no-blocks` helps to apply styles to pages using the Classic
editor. Credit to @mindctrl for the suggestion of using this in place
of `has-blocks` on pages that have blocks.

- `first-block-[block-name]` is designed to assist styling of pages
where a block requiring no padding above it appears first in the layout.

- `first-block-align-[alignment]` to adjust styles if the first block
has a certain alignment, such as full-width.

Fixes #148.