### PR TITLE
Stop background hover color appearing for mobile menu-highlight button

### DIFF
--- a/lib/output.php
+++ b/lib/output.php
@@ -74,14 +74,20 @@ function genesis_sample_css() {
 		input[type="submit"]:focus,
 		input[type="submit"]:hover,
 		.button:focus,
-		.button:hover,
-		.genesis-nav-menu > .menu-highlight > a:hover,
-		.genesis-nav-menu > .menu-highlight > a:focus,
-		.genesis-nav-menu > .menu-highlight.current-menu-item > a,
-		.content .wp-block-button .wp-block-button__link:focus,
-		.content .wp-block-button .wp-block-button__link:hover {
-			background-color: %s;
-			color: %s;
+		.button:hover {
+			background-color: %1$s;
+			color: %2$s;
+		}
+
+		@media only screen and (min-width: 960px) {
+			.genesis-nav-menu > .menu-highlight > a:hover,
+			.genesis-nav-menu > .menu-highlight > a:focus,
+			.genesis-nav-menu > .menu-highlight.current-menu-item > a,
+			.content .wp-block-button .wp-block-button__link:focus,
+			.content .wp-block-button .wp-block-button__link:hover {
+				background-color: %1$s;
+				color: %2$s;
+			}
 		}
 		',
 		$color_accent,


### PR DESCRIPTION
Prevents a mobile menu item with the `menu-highlight` class from taking a hover background color if a custom Accent Color is set in Customize → Theme Settings → Color.

Has no effect on a full-width/desktop menu item with a class of `menu-highlight`, which will still take the custom Accent Color on hover.

Fixes #151.