### PR TITLE
Remove basepath from phpcs config

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -17,7 +17,6 @@
 
 	<!-- How to scan -->
 	<arg value="sp"/> <!-- Show sniff and progress -->
-	<arg name="basepath" value="."/> <!-- Strip the file paths down to the relevant bit -->
 	<arg name="parallel" value="8"/> <!-- Enables parallel processing when available for faster results. -->
 	<arg name="extensions" value="php,css"/> <!-- Limit to PHP and CSS files -->
 


### PR DESCRIPTION
Removing the basepath allows the [phpcs extension for VS Code](https://marketplace.visualstudio.com/items?itemName=ikappas.phpcs) to correctly read the phpcs.xml.dist config.

See https://github.com/ikappas/vscode-phpcs/issues/132#issuecomment-431634772.

I was seeing errors from the VS Code phpcs extension that @nickcernis doesn't see when running `composer phpcs`. I was also seeing issues with PHPCompatibilityWP location on Windows.

This could happen if the phpcs extension is not correctly reading the config file, and so using default or other configuration.

Omitting the basepath does not appear to affect regular running of `composer phpcs` via the command line/continuous integration.

To test:

1. Make sure you open the theme folder in VS Code when working on the theme (and not a parent folder, such as the root WordPress installation).

2. Install composer globally:
- Windows: https://getcomposer.org/doc/00-intro.md#installation-windows
- Mac: Install [homebrew](https://brew.sh/), then run `brew install composer`

3. In a command line application, `cd` to the theme folder and type `composer install` to install PHP dependencies.

4. Reset any existing custom phpcs preferences in VS Code.

5. Restart VS Code.

You should see `phpcs` report the same errors that running `composer phpcs` in the command linie gives you.

Props @nickcernis for all of the above.