### PR TITLE
Correct alignwide and alignfull width table blocks

### DIFF
--- a/lib/gutenberg/front-end.css
+++ b/lib/gutenberg/front-end.css
@@ -346,6 +346,25 @@ hr.wp-block-separator {
 	padding-left: 0;
 }
 
+.full-width-content .site-container .wp-block-table.alignfull {
+	margin: 0;
+	width: 100%;
+}
+
+@media only screen and (min-width: 960px) {
+
+	.full-width-content .site-container .wp-block-table.alignwide {
+		width: calc(100% + 360px);
+	}
+
+	.full-width-content .site-container .wp-block-table.alignfull {
+		margin-left: calc(-98vw / 2 + 100% / 2);
+		margin-right: calc(-98vw / 2 + 100% / 2);
+		width: 98vw;
+	}
+
+}
+
 @media only screen and (max-width: 600px) {
 
 	.wp-block-media-text.is-stacked-on-mobile figure {


### PR DESCRIPTION
Fixes #202.

Also reduces the alignfull width table block to `98vw` to prevent table content touching viewport edges.

Props @dreamwhisper for the alignwide fix.

## Before
<img width="1742" alt="Screenshot 2019-03-18 at 10 46 40" src="https://user-images.githubusercontent.com/647669/54521399-22760900-496b-11e9-82d8-420961233ce5.png">

## After
<img width="1743" alt="Screenshot 2019-03-18 at 10 45 05" src="https://user-images.githubusercontent.com/647669/54521293-ea6ec600-496a-11e9-9f88-52b8a96e1f79.png">
