### PR TITLE
Prep for 2.9.2-dev cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Genesis Sample Theme Changelog
 
+## [Unreleased]
+*
+
 ## [2.9.1] - 2019-03-19
 * Added: Contributing guidelines.
 * Added: Tooling to lint JavaScript to WordPress coding standards (`npm run lint:js` and `npm run fix:js`).

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"description": "The sample child theme for the Genesis Framework.",
 		"author": "StudioPress",
 		"authoruri": "https://www.studiopress.com/",
-		"version": "2.9.1",
+		"version": "2.9.2-dev",
 		"tags": "one-column, two-columns, left-sidebar, right-sidebar, accessibility-ready, custom-colors, custom-logo, custom-menu, featured-images, footer-widgets, full-width-template, rtl-language-support, sticky-post, theme-options, threaded-comments, translation-ready",
 		"license": "GPL-2.0-or-later",
 		"licenseuri": "https://www.gnu.org/licenses/gpl-2.0.html",

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@ Description: This is the sample theme created for the Genesis Framework.
 Author: StudioPress
 Author URI: https://www.studiopress.com/
 
-Version: 2.9.1
+Version: 2.9.2-dev
 
 Tags: accessibility-ready, block-styles, custom-colors, custom-logo, custom-menu, editor-style, featured-images, footer-widgets, full-width-template, left-sidebar, one-column, right-sidebar, rtl-language-support, sticky-post, theme-options, threaded-comments, translation-ready, two-columns, wide-blocks
 


### PR DESCRIPTION
Bumps version, updates changelog for the 2.9.2 release cycle.

Helps to ensure the develop branch is more clearly labelled as the development version.