### PR TITLE
Prevent empty buttons from collapsing in editor

### DIFF
--- a/lib/gutenberg/style-editor.css
+++ b/lib/gutenberg/style-editor.css
@@ -338,7 +338,6 @@ hr.wp-block-separator.is-style-dots {
 	text-align: center;
 	text-decoration: none;
 	white-space: normal;
-	width: auto;
 }
 
 .wp-block-button.is-style-squared .wp-block-button__link {


### PR DESCRIPTION
Fixes button color collapsing to 1/2 width before text is entered.

![sample-button](https://user-images.githubusercontent.com/1271053/55083957-c6059e80-507a-11e9-934e-0eeb1cbfb28e.png)
