### PR TITLE
Add better .alignwide max-width in order to adapt to .content width changes

### DIFF
--- a/lib/gutenberg/front-end.css
+++ b/lib/gutenberg/front-end.css
@@ -422,7 +422,7 @@ hr.wp-block-separator {
 	.full-width-content .site-container .alignwide {
 		margin-left: -180px;
 		margin-right: -180px;
-		max-width: 1062px;
+		max-width: calc( 100% + 360px ); /* 360 equals sum of left and right margin */
 		width: auto;
 	}
 


### PR DESCRIPTION
How to check the issue:

1. Change https://github.com/studiopress/genesis-sample/blob/cf1b5b7942afb9d1612d6822b8be9afc4437dfa7/style.css#L1548 to 75%
2. Upload an image or change any block into wide using full width template
3. If you notice, the block wasn't centered

Using `calc` with `100%` of the width is more flexible.

Thanks!