### PR TITLE
Prevent layout caching on shop page

### DIFF
--- a/lib/woocommerce/woocommerce-setup.php
+++ b/lib/woocommerce/woocommerce-setup.php
@@ -56,7 +56,7 @@ add_filter( 'woocommerce_style_smallscreen_breakpoint', 'genesis_sample_woocomme
  */
 function genesis_sample_woocommerce_breakpoint() {
 
-	$current = genesis_site_layout();
+	$current = genesis_site_layout( false );
 	$layouts = array(
 		'one-sidebar' => array(
 			'content-sidebar',


### PR DESCRIPTION
https://github.com/studiopress/themes/issues/1959 - shop page does not display sidebar if genesis layout setting is cached

> When the Genesis site layout value is cached, it appears to prevent the filter in plugins/genesis-connect-woocommerce/templates/archive-product.php from having any effect, which means the shop page layout is ignored and the site layout is used as a fallback instead