### PR TITLE
Prep 2.10.0 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,17 @@
 # Genesis Sample Theme Changelog
 
-## [Unreleased]
-*
+## [2.10.0] - 2019-05-01
+Requires Genesis 2.10.0+.
+
+* Added: create a WPForms form during one-click theme setup and insert a WPForms block on the sample contact page.
+* Added: remove link in hidden title when custom logo is in use for better accessibility.
+* Changed: set full-width page layout for the Block Examples and About pages during one-click theme setup.
+* Changed: improve styling of tables.
+* Changed: improve editor button block styling.
+* Changed: clarify wording of Customizer color labels.
+* Changed: remove matchHeight script and use CSS flex instead to match heights of WooCommerce product lists.
+* Fixed: WooCommmerce shop pages now use the selected page layout instead of the default site layout on sites using object caching.
+* Fixed: update the `npm run zip` script to prevent an issue with zip decompression for apps such as Path Finder. (npm scripts are available in the version of Genesis Sample on GitHub: https://github.com/studiopress/genesis-sample/).
 
 ## [2.9.1] - 2019-03-19
 * Added: Contributing guidelines.

--- a/languages/genesis-sample.pot
+++ b/languages/genesis-sample.pot
@@ -2,15 +2,15 @@
 # This file is distributed under the GPL-2.0-or-later.=!>
 msgid ""
 msgstr ""
-"Project-Id-Version: Genesis Sample 2.9.1\n"
+"Project-Id-Version: Genesis Sample 2.10.0\n"
 "Report-Msgid-Bugs-To: StudioPress <translations@studiopress.com>\n"
-"POT-Creation-Date: 2019-03-18 16:45:28+00:00\n"
+"POT-Creation-Date: 2019-05-01 08:57:02+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "PO-Revision-Date: 2019-MO-DA HO:MI+ZONE\n"
-"Last-Translator: StudioPress <translations@studiopress.com>\n"
-"Language-Team: StudioPress <translations@studiopress.com>\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Poedit-Country: United States\n"
@@ -81,8 +81,8 @@ msgstr ""
 
 #: lib/customize.php:36
 msgid ""
-"Change the color of post info links, hover color of linked titles, hover "
-"color of menu items, and more."
+"Change the color of post info links and button blocks, the hover color of "
+"linked titles and menu items, and more."
 msgstr ""
 
 #: lib/customize.php:37
@@ -91,9 +91,8 @@ msgstr ""
 
 #: lib/customize.php:57
 msgid ""
-"Change the default hover color for button links, the menu button, and "
-"submit buttons. This setting does not apply to buttons created with the "
-"Buttons block."
+"Change the default hover color for button links, menu buttons, and submit "
+"buttons. The button block uses the Link Color."
 msgstr ""
 
 #: lib/customize.php:58
@@ -126,12 +125,16 @@ msgstr ""
 msgid "Please %1$s to <strong>enable WooCommerce support for %2$s</strong>."
 msgstr ""
 
-#: lib/woocommerce/woocommerce-setup.php:100
+#: lib/woocommerce/woocommerce-setup.php:73
 msgid "Previous Page"
 msgstr ""
 
-#: lib/woocommerce/woocommerce-setup.php:101
+#: lib/woocommerce/woocommerce-setup.php:74
 msgid "Next Page"
+msgstr ""
+
+#: lib/wpforms.php:43
+msgid "Simple Contact Form"
 msgstr ""
 
 #. Theme Name of the plugin/theme

--- a/lib/gutenberg/front-end.css
+++ b/lib/gutenberg/front-end.css
@@ -422,7 +422,7 @@ hr.wp-block-separator {
 	.full-width-content .site-container .alignwide {
 		margin-left: -180px;
 		margin-right: -180px;
-		max-width: calc( 100% + 360px ); /* 360 equals sum of left and right margin */
+		max-width: calc(100% + 360px); /* 360 equals sum of left and right margin */
 		width: auto;
 	}
 

--- a/lib/woocommerce/genesis-sample-woocommerce.css
+++ b/lib/woocommerce/genesis-sample-woocommerce.css
@@ -888,4 +888,3 @@ div.woocommerce-info.wc-memberships-restriction-message.wc-memberships-restricte
 	}
 
 }
-

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"description": "The sample child theme for the Genesis Framework.",
 		"author": "StudioPress",
 		"authoruri": "https://www.studiopress.com/",
-		"version": "2.9.2-dev",
+		"version": "2.10.0",
 		"tags": "one-column, two-columns, left-sidebar, right-sidebar, accessibility-ready, custom-colors, custom-logo, custom-menu, featured-images, footer-widgets, full-width-template, rtl-language-support, sticky-post, theme-options, threaded-comments, translation-ready",
 		"license": "GPL-2.0-or-later",
 		"licenseuri": "https://www.gnu.org/licenses/gpl-2.0.html",

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@ Description: This is the sample theme created for the Genesis Framework.
 Author: StudioPress
 Author URI: https://www.studiopress.com/
 
-Version: 2.9.2-dev
+Version: 2.10.0
 
 Tags: accessibility-ready, block-styles, custom-colors, custom-logo, custom-menu, editor-style, featured-images, footer-widgets, full-width-template, left-sidebar, one-column, right-sidebar, rtl-language-support, sticky-post, theme-options, threaded-comments, translation-ready, two-columns, wide-blocks
 


### PR DESCRIPTION
Completes the release checklist in https://github.com/studiopress/genesis-sample/issues/235 (except for the final release steps).