### PR TITLE
Prevent form creation attempts if WPForms Lite version is < 1.5.2

### DIFF
--- a/lib/wpforms.php
+++ b/lib/wpforms.php
@@ -24,6 +24,18 @@ function studiopress_maybe_create_wpforms_form() { // phpcs:ignore -- studiopres
 		return;
 	}
 
+	// Form creation requires WPForms 1.5.2 or higher.
+	// If the site already as an earlier version of the plugin installed, don't create a form.
+	// Plugins do not get upgraded during one-click theme setup.
+	if ( function_exists( 'get_plugins' ) ) {
+		$plugin_data          = get_plugins();
+		$wpforms_lite_version = isset( $plugin_data['wpforms-lite/wpforms.php']['Version'] ) ? $plugin_data['wpforms-lite/wpforms.php']['Version'] : '';
+
+		if ( version_compare( $wpforms_lite_version, '1.5.2', '<' ) ) {
+			return;
+		}
+	}
+
 	$existing_form_id = get_option( 'genesis_onboarding_wpforms_id' );
 
 	if ( $existing_form_id ) {


### PR DESCRIPTION
Creating a working form via the WPForms API requires 1.5.2 or higher.

If a site already has WPForms Lite installed but it's an older version, form creation will appear to complete, but the form be broken (missing labels on submit button and submission message).

This PR checks that WPForms Lite is 1.5.2 or higher installed before creating the form. 

### To test

1. Ensure the `genesis_onboarding_wpforms_id` option is empty.

```shell
wp option delete genesis_onboarding_wpforms_id
```

2. Install a version of the plugin pre 1.5.2 that shows the issue:

https://downloads.wordpress.org/plugin/wpforms-lite.1.5.1.3.zip

```shell
wp plugin install wpforms-lite --version=1.5.1.3 --force --activate
```

3. Complete one-click theme setup. You should see the placeholder text on the created contact page.

4. Upgrade to the latest version of WP Forms Lite, or delete the plugin.

5. Complete one-click theme setup again. You should see a working contact form on the created contact page.