### PR TITLE
Remove 404 page support from accessibility config

### DIFF
--- a/config/accessibility.php
+++ b/config/accessibility.php
@@ -12,7 +12,6 @@
  * Genesis Accessibility features to support.
  */
 return array(
-	'404-page',
 	'drop-down-menu',
 	'headings',
 	'search-form',


### PR DESCRIPTION
This is no longer used in Genesis, so has no effect.