### PR TITLE
Delete Genesis nav right extra filter removal

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -147,10 +147,6 @@ genesis_unregister_layout( 'content-sidebar-sidebar' );
 genesis_unregister_layout( 'sidebar-content-sidebar' );
 genesis_unregister_layout( 'sidebar-sidebar-content' );
 
-// Removes output of primary navigation right extras.
-remove_filter( 'genesis_nav_items', 'genesis_nav_right', 10, 2 );
-remove_filter( 'wp_nav_menu_items', 'genesis_nav_right', 10, 2 );
-
 add_filter( 'genesis_customizer_theme_settings_config', 'genesis_sample_remove_customizer_settings' );
 /**
  * Removes output of header and front page breadcrumb settings in the Customizer.


### PR DESCRIPTION
These are no longer applied in Genesis 3.0.