### PR TITLE
Use theme name instead of hard-coding 'genesis-sample' for handles

### DIFF
--- a/lib/gutenberg/init.php
+++ b/lib/gutenberg/init.php
@@ -36,7 +36,7 @@ function genesis_sample_block_editor_styles() {
 	$appearance = genesis_get_config( 'appearance' );
 
 	wp_enqueue_style(
-		'genesis-sample-gutenberg-fonts',
+		genesis_get_theme_handle() . '-gutenberg-fonts',
 		$appearance['fonts-url'],
 		array(),
 		genesis_get_theme_version()

--- a/lib/gutenberg/init.php
+++ b/lib/gutenberg/init.php
@@ -17,7 +17,7 @@ add_action( 'wp_enqueue_scripts', 'genesis_sample_enqueue_gutenberg_frontend_sty
 function genesis_sample_enqueue_gutenberg_frontend_styles() {
 
 	wp_enqueue_style(
-		'genesis-sample-gutenberg',
+		genesis_get_theme_handle() . '-gutenberg',
 		get_stylesheet_directory_uri() . '/lib/gutenberg/front-end.css',
 		array( genesis_get_theme_handle() ),
 		genesis_get_theme_version()

--- a/lib/gutenberg/inline-styles.php
+++ b/lib/gutenberg/inline-styles.php
@@ -85,7 +85,7 @@ function genesis_sample_custom_gutenberg_admin_css() {
 }
 CSS;
 
-	wp_add_inline_style( 'genesis-sample-gutenberg-fonts', $css );
+	wp_add_inline_style( genesis_get_theme_handle() . '-gutenberg-fonts', $css );
 
 }
 


### PR DESCRIPTION
Fixes an issue where changing the theme name would result in:

1. No front end inline styles being output (fixed in `inline-styles.php`).
2. Stylesheet handles that still contained 'genesis-sample-' (fixed in `init.php`).

Suggest we release as part of a 3.0.1 update.