### PR TITLE
Prepare Genesis Sample 3.0.1 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Genesis Sample Theme Changelog
 
+## [3.0.1] - 2019-06-25
+* Use current theme name instead of 'genesis-sample' when enqueueing assets. This ensures assets continue to load if the theme is renamed.
+
 ## [3.0.0] - 2019-06-19
 Requires Genesis 3.0.0+.
 
@@ -139,6 +142,7 @@ Requires Genesis 2.8.0+.
 * Set localization.
 * Update XML file.
 
+[3.0.1]: https://github.com/studiopress/genesis-sample/compare/3.0.0...3.0.1
 [3.0.0]: https://github.com/studiopress/genesis-sample/compare/2.10.0...3.0.0
 [2.10.0]: https://github.com/studiopress/genesis-sample/compare/2.9.1...2.10.0
 [2.9.1]: https://github.com/studiopress/genesis-sample/compare/2.9.0...2.9.1

--- a/languages/genesis-sample.pot
+++ b/languages/genesis-sample.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GPL-2.0-or-later.=!>
 msgid ""
 msgstr ""
-"Project-Id-Version: Genesis Sample 3.0.0\n"
+"Project-Id-Version: Genesis Sample 3.0.1\n"
 "Report-Msgid-Bugs-To: StudioPress <translations@studiopress.com>\n"
-"POT-Creation-Date: 2019-06-17 13:33:45+00:00\n"
+"POT-Creation-Date: 2019-06-24 16:51:49+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"description": "The sample child theme for the Genesis Framework.",
 		"author": "StudioPress",
 		"authoruri": "https://www.studiopress.com/",
-		"version": "3.0.0",
+		"version": "3.0.1",
 		"tags": "one-column, two-columns, left-sidebar, right-sidebar, accessibility-ready, custom-colors, custom-logo, custom-menu, featured-images, footer-widgets, full-width-template, rtl-language-support, sticky-post, theme-options, threaded-comments, translation-ready",
 		"license": "GPL-2.0-or-later",
 		"licenseuri": "https://www.gnu.org/licenses/gpl-2.0.html",

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@ Description: This is the sample theme created for the Genesis Framework.
 Author: StudioPress
 Author URI: https://www.studiopress.com/
 
-Version: 3.0.0
+Version: 3.0.1
 
 Tags: accessibility-ready, block-styles, custom-colors, custom-logo, custom-menu, editor-style, featured-images, footer-widgets, full-width-template, left-sidebar, one-column, right-sidebar, rtl-language-support, sticky-post, theme-options, threaded-comments, translation-ready, two-columns, wide-blocks
 


### PR DESCRIPTION
For https://github.com/studiopress/genesis-sample/issues/271.

I set the release date to tomorrow (2019-06-25) in the changelog, but can adjust if needed.

This is a bug fix release to correct https://github.com/studiopress/genesis-sample/pull/270. There is no additional documentation required.