### PR TITLE
Add footer widgets to onboarding config

### DIFF
--- a/config/onboarding.php
+++ b/config/onboarding.php
@@ -101,4 +101,33 @@ return array(
 			),
 		),
 	),
+	'widgets'          => array(
+		'footer-1' => array(
+			array(
+				'type' => 'text',
+				'args' => array(
+					'title' => 'Design',
+					'text'  => '<p>With an emphasis on typography, white space, and mobile-optimized design, your website will look absolutely breathtaking.</p><p><a href="#">Learn more about design</a>.</p>',
+				),
+			),
+		),
+		'footer-2' => array(
+			array(
+				'type' => 'text',
+				'args' => array(
+					'title' => 'Content',
+					'text'  => '<p>Our team will teach you the art of writing audience-focused content that will help you achieve the success you truly deserve.</p><p><a href="#">Learn more about content</a>.</p>',
+				),
+			),
+		),
+		'footer-3' => array(
+			array(
+				'type' => 'text',
+				'args' => array(
+					'title' => 'Strategy',
+					'text'  => '<p>We help creative entrepreneurs build their digital business by focusing on three key elements of a successful online platform.</p><p><a href="#">Learn more about strategy</a>.</p>',
+				),
+			),
+		),
+	),
 );

--- a/config/onboarding.php
+++ b/config/onboarding.php
@@ -106,8 +106,10 @@ return array(
 			array(
 				'type' => 'text',
 				'args' => array(
-					'title' => 'Design',
-					'text'  => '<p>With an emphasis on typography, white space, and mobile-optimized design, your website will look absolutely breathtaking.</p><p><a href="#">Learn more about design</a>.</p>',
+					'title'  => 'Design',
+					'text'   => '<p>With an emphasis on typography, white space, and mobile-optimized design, your website will look absolutely breathtaking.</p><p><a href="#">Learn more about design</a>.</p>',
+					'filter' => 1,
+					'visual' => 1,
 				),
 			),
 		),
@@ -115,8 +117,10 @@ return array(
 			array(
 				'type' => 'text',
 				'args' => array(
-					'title' => 'Content',
-					'text'  => '<p>Our team will teach you the art of writing audience-focused content that will help you achieve the success you truly deserve.</p><p><a href="#">Learn more about content</a>.</p>',
+					'title'  => 'Content',
+					'text'   => '<p>Our team will teach you the art of writing audience-focused content that will help you achieve the success you truly deserve.</p><p><a href="#">Learn more about content</a>.</p>',
+					'filter' => 1,
+					'visual' => 1,
 				),
 			),
 		),
@@ -124,8 +128,10 @@ return array(
 			array(
 				'type' => 'text',
 				'args' => array(
-					'title' => 'Strategy',
-					'text'  => '<p>We help creative entrepreneurs build their digital business by focusing on three key elements of a successful online platform.</p><p><a href="#">Learn more about strategy</a>.</p>',
+					'title'  => 'Strategy',
+					'text'   => '<p>We help creative entrepreneurs build their digital business by focusing on three key elements of a successful online platform.</p><p><a href="#">Learn more about strategy</a>.</p>',
+					'filter' => 1,
+					'visual' => 1,
 				),
 			),
 		),


### PR DESCRIPTION
Ensures footer widgets are imported during one-click theme setup.

Dependent on widget import being implemented in Genesis 3.1. See https://github.com/studiopress/genesis/issues/2141.

I opened this so that we can test the feature in Genesis 3.1. Suggest waiting until the feature is merged there before merging this into Sample.

Fixes #276.