### PR TITLE
Ensure a logo width of lower than 100 cannot be saved

### DIFF
--- a/lib/customize.php
+++ b/lib/customize.php
@@ -98,7 +98,7 @@ function genesis_sample_customizer_register( $wp_customize ) {
  * @return int The new width.
  */
 function genesis_sample_sanitize_min_logo_width( $width ) {
-	$width = absint ( $width );
+	$width = absint( $width );
 
 	if ( $width < 100 ) {
 		$width = 100;

--- a/lib/customize.php
+++ b/lib/customize.php
@@ -68,7 +68,7 @@ function genesis_sample_customizer_register( $wp_customize ) {
 		'genesis_sample_logo_width',
 		[
 			'default'           => 350,
-			'sanitize_callback' => 'absint',
+			'sanitize_callback' => 'genesis_sample_sanitize_min_logo_width',
 		]
 	);
 
@@ -89,4 +89,20 @@ function genesis_sample_customizer_register( $wp_customize ) {
 		]
 	);
 
+}
+
+/**
+ * Sanitizes logo width to clamp minimum to 100 or higher.
+ *
+ * @param int $width The current width.
+ * @return int The new width.
+ */
+function genesis_sample_sanitize_min_logo_width( $width ) {
+	$width = absint ( $width );
+
+	if ( $width < 100 ) {
+		$width = 100;
+	}
+
+	return $width;
 }

--- a/lib/customize.php
+++ b/lib/customize.php
@@ -68,7 +68,8 @@ function genesis_sample_customizer_register( $wp_customize ) {
 		'genesis_sample_logo_width',
 		[
 			'default'           => 350,
-			'sanitize_callback' => 'genesis_sample_sanitize_min_logo_width',
+			'sanitize_callback' => 'absint',
+			'validate_callback' => 'genesis_sample_validate_logo_width',
 		]
 	);
 
@@ -92,17 +93,18 @@ function genesis_sample_customizer_register( $wp_customize ) {
 }
 
 /**
- * Sanitizes logo width to clamp minimum to 100 or higher.
+ * Displays a message if the entered width is not numeric or greater than 100.
  *
- * @param int $width The current width.
+ * @param object $validity The validity status.
+ * @param int    $width The width entered by the user.
  * @return int The new width.
  */
-function genesis_sample_sanitize_min_logo_width( $width ) {
-	$width = absint( $width );
-
-	if ( $width < 100 ) {
-		$width = 100;
+function genesis_sample_validate_logo_width( $validity, $width ) {
+	if ( empty( $width ) || ! is_numeric( $width ) ) {
+		$validity->add( 'required', __( 'You must supply a valid number.', 'genesis-sample' ) );
+	} elseif ( $value < 100 ) {
+		$validity->add( 'logo_too_small', __( 'The maximum logo width cannot be less than 100.', 'genesis-sample' ) );
 	}
 
-	return $width;
+	return $validity;
 }

--- a/lib/customize.php
+++ b/lib/customize.php
@@ -103,7 +103,7 @@ function genesis_sample_validate_logo_width( $validity, $width ) {
 	if ( empty( $width ) || ! is_numeric( $width ) ) {
 		$validity->add( 'required', __( 'You must supply a valid number.', 'genesis-sample' ) );
 	} elseif ( $value < 100 ) {
-		$validity->add( 'logo_too_small', __( 'The maximum logo width cannot be less than 100.', 'genesis-sample' ) );
+		$validity->add( 'logo_too_small', __( 'The logo width cannot be less than 100.', 'genesis-sample' ) );
 	}
 
 	return $validity;


### PR DESCRIPTION
**Summary of change:**
Even though the “maximum logo width” field has a min attribute of 100, a value of lower than 100 can still be saved if entered manually rather than using the input field stepper controls.

This commit adds a custom sanitization callback to prevent values under 100 from being saved.

Reported by Marcy Diaz in Slack.

**Have the changes in this PR been added to the documentation for this project?**
Does not apply

**How to test:**
1. Save a logo at Customize -> Site Identity
2. Set the maximum width field to 50.
3. Publish the changes.
4. Confirm that the maximum width field value now reads 100 when refreshing the Customizer.
5. Confirm that the image appears at a maximum width of 100 and not 50.

**Suggested Changelog Entry:**
Ensure logos cannot appear at a width lower than 100px wide.