### PR TITLE
Feature/landing page settings

### DIFF
--- a/config/onboarding-shared.php
+++ b/config/onboarding-shared.php
@@ -76,6 +76,8 @@ return [
 			'comment_status' => 'closed',
 			'ping_status'    => 'closed',
 			'meta_input'     => [
+				'_genesis_layout'              => 'full-width-content',
+				'_genesis_hide_breadcrumbs'    => true,
 				'_genesis_hide_singular_image' => true,
 			],
 		],

--- a/page-templates/landing.php
+++ b/page-templates/landing.php
@@ -51,9 +51,6 @@ remove_action( 'genesis_header', 'genesis_header_markup_close', 15 );
 // Removes navigation.
 remove_theme_support( 'genesis-menus' );
 
-// Removes breadcrumbs.
-remove_action( 'genesis_before_loop', 'genesis_do_breadcrumbs' );
-
 // Removes footer widgets.
 remove_action( 'genesis_before_footer', 'genesis_footer_widget_areas' );
 

--- a/page-templates/landing.php
+++ b/page-templates/landing.php
@@ -43,9 +43,6 @@ function genesis_sample_dequeue_skip_links() {
 
 }
 
-// Forces full width content layout.
-add_filter( 'genesis_site_layout', '__genesis_return_full_width_content' );
-
 // Removes site header elements.
 remove_action( 'genesis_header', 'genesis_header_markup_open', 5 );
 remove_action( 'genesis_header', 'genesis_do_header' );

--- a/style.css
+++ b/style.css
@@ -1582,8 +1582,7 @@ p.entry-meta {
 		float: right;
 	}
 
-	.full-width-content .content,
-	.landing-page .content {
+	.full-width-content .content {
 		float: none;
 		margin-left: auto;
 		margin-right: auto;


### PR DESCRIPTION
**Summary of change:**
Updates the landing page template and OCTS landing page import to allow alternate layouts and breadcrumbs.

The landing page has disallowed updating the layout setting, but that leaves a non-functional layout option. With 3.1, the breadcrumb setting would also not work. This enables those 2 features and sets the imported landing page meta.

**This PR has been:**
- [x] Linted for syntax errors
- [x] Tested against the WordPress coding standards

**Have the changes in this PR been added to the documentation for this project?**
No, but @susannelson may want to review.

**How to test:**

1. Use this branch with Genesis 3.1 Beta/RC.
2. Select and install a starter pack.
3. Verify the landing page template is full width and does not show breadcrumbs.
4. Edit the page to show breadcrumbs and a different layout and verify the changes are reflected on the front end.

**Suggested Changelog Entry:**
Changed: Allow breadcrumbs and layout settings to be used on the landing page template.
