### PR TITLE
Refactor genesis_sample_secondary_menu_args function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Requires Genesis 3.1.0+
 * Add version number to zip files generated with `npm run zip`. ([GitHub version](https://github.com/studiopress/genesis-sample/) only.)
 * Update the phpcs config to include a PHP short array rule and update PHP and WordPress testing versions. ([GitHub version](https://github.com/studiopress/genesis-sample/) only.)
 * Update developer dependencies. ([GitHub version](https://github.com/studiopress/genesis-sample/) only.)
+* Simplified `genesis_sample_secondary_menu_args` function.
 
 ## [3.0.1] - 2019-06-25
 * Use current theme name instead of 'genesis-sample' when enqueueing assets. This ensures assets continue to load if the theme is renamed.

--- a/functions.php
+++ b/functions.php
@@ -154,18 +154,17 @@ add_filter( 'wp_nav_menu_args', 'genesis_sample_secondary_menu_args' );
 /**
  * Reduces secondary navigation menu to one level depth.
  *
- * @since 2.2.3
+ * @since 3.1.0
  *
  * @param array $args Original menu options.
  * @return array Menu options with depth set to 1.
  */
 function genesis_sample_secondary_menu_args( $args ) {
 
-	if ( 'secondary' !== $args['theme_location'] ) {
-		return $args;
+	if ( 'secondary' === $args['theme_location'] ) {
+		$args['depth'] = 1;
 	}
 
-	$args['depth'] = 1;
 	return $args;
 
 }

--- a/functions.php
+++ b/functions.php
@@ -154,7 +154,7 @@ add_filter( 'wp_nav_menu_args', 'genesis_sample_secondary_menu_args' );
 /**
  * Reduces secondary navigation menu to one level depth.
  *
- * @since 3.1.0
+ * @since 2.2.3
  *
  * @param array $args Original menu options.
  * @return array Menu options with depth set to 1.


### PR DESCRIPTION
**Summary of change:**
Simplifies the genesis_sample_secondary_menu_args function.

**Have the changes in this PR been added to the documentation for this project?**
Yes - added to 3.1.0 changelog

**How to test:**
N/a

**Suggested Changelog Entry: (already added)**
Simplified `genesis_sample_secondary_menu_args` function.

**Additional Information**
Just a little thing that has been bugging me.
