### PR TITLE
Fix/woocommerce flex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Genesis Sample Theme Changelog
 
+## Unreleased
+
+### Fixed
+* Ensure that the flexbox styles equally apply to the WooCommerce shop page and a page using the [products] shortcode.
+* Ensure that general list styles do not apply to WooCommerce product blocks.
+
 ## [3.1.0] - 2019-08-21
 Requires Genesis 3.1.0+
 

--- a/lib/woocommerce/genesis-sample-woocommerce.css
+++ b/lib/woocommerce/genesis-sample-woocommerce.css
@@ -81,7 +81,9 @@ Loaded on WooCommerce pages */
 .woocommerce .products ul::after,
 .woocommerce .products ul::before,
 .woocommerce ul.products::after,
-.woocommerce ul.products::before {
+.woocommerce ul.products::before,
+.woocommerce ul.products .product::after,
+.woocommerce ul.products .product::before {
 	display: none;
 }
 
@@ -828,7 +830,8 @@ div.woocommerce-info.wc-memberships-restriction-message.wc-memberships-restricte
 
 @media only screen and (min-width: 860px) {
 
-	.full-width-content .woocommerce ul.products {
+	.full-width-content .woocommerce ul.products
+	.full-width-content.woocommerce ul.products {
 		justify-content: flex-start;
 	}
 
@@ -883,7 +886,9 @@ div.woocommerce-info.wc-memberships-restriction-message.wc-memberships-restricte
 @media only screen and (min-width: 1140px) {
 
 	.content-sidebar .woocommerce ul.products,
-	.sidebar-content .woocommerce ul.products {
+	.sidebar-content .woocommerce ul.products,
+	.content-sidebar.woocommerce ul.products,
+	.sidebar-content.woocommerce ul.products {
 		justify-content: flex-start;
 	}
 

--- a/lib/woocommerce/genesis-sample-woocommerce.css
+++ b/lib/woocommerce/genesis-sample-woocommerce.css
@@ -45,6 +45,17 @@ Loaded on WooCommerce pages */
 	flex-shrink: 0; /* IE 11 height fix */
 }
 
+/* WooCommerce Blocks
+---------------------------------------------------------------------------- */
+
+ul.wc-block-grid__products {
+	padding-left: 0;
+}
+
+ul.wc-block-grid__products > li {
+	list-style-type: none;
+}
+
 
 /* WooCommerce Product Gallery
 ---------------------------------------------------------------------------- */


### PR DESCRIPTION
**Summary of change:**
<!-- Provide a short but detailed summary of the changes included in this PR -->

- Ensure that the flexbox styles equally apply to the WooCommerce shop page and a page using the [products] shortcode.
- Ensure that general list styles do not apply to WooCommerce product blocks. 

**Have the changes in this PR been added to the documentation for this project?**
<!--
Yes / No / Does not apply
(if No, please create and link to the issue that identifies the need for documentation)
-->
n/a

**How to test:**
<!-- Provide as detailed a description for how to test this PR. -->

- Set up the standard WooCommerce shop page & a page using the `[products]` shortcode.
- Check that flexbox styling applies equally to both pages.

- Add a product block to a page (Best Selling Products, Hand Picked Products, etc)
- Make sure that list styling and padding is not applied to the block product list items.

**Suggested Changelog Entry:**
<!-- Provide a short description of the changes in this PR for inclusion in the changelog. -->
Fixed: Ensure that the flexbox styles equally apply to the WooCommerce shop page and a page using the [products] shortcode.
Fixed: Ensure that general list styles do not apply to WooCommerce product blocks. 
<!-- You can use this space to provide any additional information that may be relevant to this PR -->
