### PR TITLE
Add 3.2 Lazy Load

### DIFF
--- a/config/theme-supports.php
+++ b/config/theme-supports.php
@@ -30,7 +30,7 @@ return [
 		'search-form',
 		'skip-links',
 	],
-	'genesis-lazy-load-images' => '',
+	'genesis-lazy-load-images'        => '',
 	'genesis-after-entry-widget-area' => '',
 	'genesis-footer-widgets'          => 3,
 	'genesis-menus'                   => [

--- a/config/theme-supports.php
+++ b/config/theme-supports.php
@@ -30,6 +30,7 @@ return [
 		'search-form',
 		'skip-links',
 	],
+	'genesis-lazy-load-images' => '',
 	'genesis-after-entry-widget-area' => '',
 	'genesis-footer-widgets'          => 3,
 	'genesis-menus'                   => [


### PR DESCRIPTION

**Summary of change:**
<!-- Provide a short but detailed summary of the changes included in this PR -->

Adds Genesis 3.2 lazy loading feature to Sample.

**Have the changes in this PR been added to the documentation for this project?**
<!--
Yes / No / Does not apply
(if No, please create and link to the issue that identifies the need for documentation)
-->

n/a

**How to test:**
<!-- Provide as detailed a description for how to test this PR. -->

Use the Genesis develop branch or 3.2 beta.

1. Enable the display of featured images on archives and single posts in Theme Settings.
2. Be sure some of your posts have set a featured image.
3. View the posts, inspect the images, verify that loading="lazy" is added to the attributes of the image element.

<!-- If this PR is in reference to an existing issue, link it here. -->
**See:** https://github.com/studiopress/genesis/issues/2500

**Suggested Changelog Entry:**
<!-- Provide a short description of the changes in this PR for inclusion in the changelog. -->

Added: Theme support for lazy loading of images for users browsing with Chrome 76+. 

<!-- You can use this space to provide any additional information that may be relevant to this PR -->
