### PR TITLE
Add new HTML5 theme support

### DIFF
--- a/config/theme-supports.php
+++ b/config/theme-supports.php
@@ -23,6 +23,8 @@ return [
 		'comment-list',
 		'gallery',
 		'search-form',
+		'script',
+		'style',
 	],
 	'genesis-accessibility'           => [
 		'drop-down-menu',


### PR DESCRIPTION
**Summary of change:**
WordPress 5.3 is introducing new arguments for add_theme_support, to
prevent validation warnings for style/script files. This resolves issue
#313.

**Have the changes in this PR been added to the documentation for this project?**
No: it should be added to [this snippet](https://my.studiopress.com/documentation/snippets/html5/enable-html5-markup/).

**How to test:**
Add to a site running WordPress 5.3 and confirm that script/style `type` is no longer output.

**See:** #313
**Fixes:** #313

**Suggested Changelog Entry:**
Update HTML5 theme support to fix script/style validation warnings.
