### PR TITLE
Updates/genesis 32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * HTML5 supports for `scripts` and `styles` available in WordPress 5.3.
 * Support for `genesis-lazy-load-images` available in Genesis 3.2.
 * WordPress 5.3 alignment classes.
+* Set post meta on theme activation.
 
 ### Changed
 * Block width CSS for nested blocks.
@@ -13,6 +14,8 @@
 * CSS for image, gallery, and gallery item figcaptions.
 * Spacing between WooCommerce products.
 * CSS for tables for better consistency between editor and front end and to allow for new WordPress 5.3 settings.
+* Allow footer widgets to be displayed on the landing page template.
+* Changed: Set imported landing page meta to hide footer widgets. Requires Genesis 3.2 or higher.
 
 ### Fixed
 * Ensure that the flexbox styles equally apply to the WooCommerce shop page and a page using the [products] shortcode.

--- a/config/child-theme-settings.php
+++ b/config/child-theme-settings.php
@@ -24,6 +24,8 @@ return [
 		'content_archive'           => 'full',
 		'content_archive_limit'     => 0,
 		'content_archive_thumbnail' => 0,
+		'entry_meta_after_content'  => '[post_categories] [post_tags]',
+		'entry_meta_before_content' => '[post_date] ' . __( 'by', 'genesis-sample' ) . ' [post_author_posts_link] [post_comments] [post_edit]',
 		'image_size'                => 'genesis-singular-images',
 		'image_alignment'           => 'aligncenter',
 		'posts_nav'                 => 'numeric',

--- a/config/onboarding-shared.php
+++ b/config/onboarding-shared.php
@@ -79,6 +79,7 @@ return [
 				'_genesis_layout'              => 'full-width-content',
 				'_genesis_hide_breadcrumbs'    => true,
 				'_genesis_hide_singular_image' => true,
+				'_genesis_hide_footer_widgets' => true,
 			],
 		],
 	],

--- a/page-templates/landing.php
+++ b/page-templates/landing.php
@@ -51,9 +51,6 @@ remove_action( 'genesis_header', 'genesis_header_markup_close', 15 );
 // Removes navigation.
 remove_theme_support( 'genesis-menus' );
 
-// Removes footer widgets.
-remove_action( 'genesis_before_footer', 'genesis_footer_widget_areas' );
-
 // Removes site footer elements.
 remove_action( 'genesis_footer', 'genesis_footer_markup_open', 5 );
 remove_action( 'genesis_footer', 'genesis_do_footer' );


### PR DESCRIPTION
Based on updates/wordpress-53 branch.

**Summary of change:**
<!-- Provide a short but detailed summary of the changes included in this PR -->
- Sets post meta on theme activation
- Allows footer widgets to be used on landing page template
- Sets post meta to hide footer widgets on imported landing page

**Have the changes in this PR been added to the documentation for this project?**
<!--
Yes / No / Does not apply
(if No, please create and link to the issue that identifies the need for documentation)
-->
n/a

**How to test:**
<!-- Provide as detailed a description for how to test this PR. -->

- Change the post meta (before and after) to something other than default.
- Activate the theme using the `updates/genesis-32` branch.
- Verify the post meta are set as the default genesis meta.
- Using a landing page template, test that footer widgets display if not hidden with the checkbox setting in the genesis sidebar.
- When importing the theme content, test that the footer widgets do not display on the imported landing page.

**Suggested Changelog Entry:**
<!-- Provide a short description of the changes in this PR for inclusion in the changelog. -->
See Changelog entries.
<!-- You can use this space to provide any additional information that may be relevant to this PR -->
