### PR TITLE
Update phpcs.xml.dist and fix warnings

### DIFF
--- a/lib/woocommerce/woocommerce-notice.php
+++ b/lib/woocommerce/woocommerce-notice.php
@@ -115,8 +115,8 @@ function genesis_sample_reset_woocommerce_notice() {
 	global $wpdb;
 
 	$args  = [
-		'meta_key'   => $wpdb->prefix . 'genesis_sample_woocommerce_message_dismissed',
-		'meta_value' => 1,
+		'meta_key'   => $wpdb->prefix . 'genesis_sample_woocommerce_message_dismissed', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		'meta_value' => 1, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 	];
 	$users = get_users( $args );
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -40,6 +40,10 @@
 		<severity>0</severity>
 	</rule>
 
+	<rule ref="WordPress">
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+	</rule>
+
 	<!-- Allow theme-specific exceptions to WordPress filename rules. -->
 	<rule ref="WordPress.Files.FileName">
 		<properties>


### PR DESCRIPTION
WPCS 2.2.0 issues warnings for short array syntax usage. These are intended for WordPress core and are safe to ignore. This PR excludes short array syntax warnings from our phpcs standards checks.

It also ignores meta_key and meta_value warnings, which we depend on for the WooCommerce code.

### To test

- Delete composer.lock (ensures the latest version of wpcs is installed in the third step, but `composer update` usually works too).
- Run rm -rf vendor from the theme directory.
- Run composer install and then composer phpcs

There should be no warnings.