### PR TITLE
Update custom class for new button markup

### DIFF
--- a/config/import/content/home-black-white.php
+++ b/config/import/content/home-black-white.php
@@ -83,8 +83,8 @@ return <<<CONTENT
 <!-- /wp:atomic-blocks/ab-column -->
 
 <!-- wp:atomic-blocks/ab-column -->
-<div class="wp-block-atomic-blocks-ab-column ab-block-layout-column"><div class="ab-block-layout-column-inner"><!-- wp:buttons {"align":"right"} -->
-<div class="wp-block-buttons alignright"><!-- wp:button {"customTextColor":"#ffffff","borderRadius":0,"className":"is-style-outline"} -->
+<div class="wp-block-atomic-blocks-ab-column ab-block-layout-column"><div class="ab-block-layout-column-inner"><!-- wp:buttons {"align":"right","className":"home-contact"} -->
+<div class="wp-block-buttons alignright home-contact"><!-- wp:button {"customTextColor":"#ffffff","borderRadius":0,"className":"is-style-outline"} -->
 <div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-text-color no-border-radius" href="#" style="color:#ffffff">Get in touch</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div></div>

--- a/config/import/content/home-color.php
+++ b/config/import/content/home-color.php
@@ -83,8 +83,8 @@ return <<<CONTENT
 <!-- /wp:atomic-blocks/ab-column -->
 
 <!-- wp:atomic-blocks/ab-column -->
-<div class="wp-block-atomic-blocks-ab-column ab-block-layout-column"><div class="ab-block-layout-column-inner"><!-- wp:buttons {"align":"right"} -->
-<div class="wp-block-buttons alignright"><!-- wp:button {"customTextColor":"#ffffff","borderRadius":0,"className":"is-style-outline"} -->
+<div class="wp-block-atomic-blocks-ab-column ab-block-layout-column"><div class="ab-block-layout-column-inner"><!-- wp:buttons {"align":"right","className":"home-contact"} -->
+<div class="wp-block-buttons alignright home-contact"><!-- wp:button {"customTextColor":"#ffffff","borderRadius":0,"className":"is-style-outline"} -->
 <div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-text-color no-border-radius" href="#" style="color:#ffffff">Get in touch</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div></div>

--- a/lib/gutenberg/front-end.css
+++ b/lib/gutenberg/front-end.css
@@ -102,7 +102,8 @@
 
 @media only screen and (max-width: 600px) {
 
-	.wp-block-button.home-contact {
+	.wp-block-button.home-contact,
+	.wp-block-buttons.home-contact {
 		float: left;
 		margin-left: 0;
 	}


### PR DESCRIPTION
Updates the homepage _Get in touch_ button to allow it to align left below 600px. The custom class was available with the previous markup. This adds it to `wp-block-buttons`.

### How to test
<!-- Detailed steps to test this PR. -->
1. Install the theme, then import either the color or black and white starter pack through OCTS.
2. View the front end.
3. Reduce the screen width below 600px.
5. The Get in touch button should alignleft (uses `home-contact` class).

### Documentation
<!-- No documentation required. -->
<!-- Documentation required. See #xxx. -->
<!-- PR includes documentation. -->

n/a

### Suggested changelog entry
<!-- A short description for the changelog. -->
- 
n/a

### Notes
<!-- Additional information for reviewers. -->
