### PR TITLE
Make version null to prevent poor encoding and removal of any duplicate font families

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -75,7 +75,7 @@ function genesis_sample_enqueue_scripts_styles() {
 		genesis_get_theme_handle() . '-fonts',
 		$appearance['fonts-url'],
 		[],
-		genesis_get_theme_version()
+		null
 	);
 
 	wp_enqueue_style( 'dashicons' );


### PR DESCRIPTION
If a user changes `fonts-url` to something like `https://fonts.googleapis.com/css2?family=Alex+Brush&family=Open+Sans:wght@400;700;800&display=swap`, WordPress's `add_query_arg` breaks the URL with `wp_parse_str` and 
`urlencode_deep` as Google cannot handle the encodings.

### How to test
1. Change `fonts-url` in `config/appearance` to `https://fonts.googleapis.com/css2?family=Alex+Brush&family=Open+Sans:wght@400;700;800&display=swap`
1. Load page & check the output `link` tag for `id="genesis-sample-fonts-css"`.

### Documentation
PR includes documentation.

### Suggested changelog entry
- Fix Google Fonts URL output.

### Notes
See WP Core Tickets: https://core.trac.wordpress.org/ticket/50106 and https://core.trac.wordpress.org/ticket/49742.
