### PR TITLE
ci: Working CircleCI Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp
+      - set_env_vars
       - run: npm ci
       - run: npm run zip
       - mkdir_artifacts
@@ -92,6 +93,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp
+      - set_env_vars
       - run: npm run prep:piservice /tmp/artifacts
       - persist_to_workspace:
           root: /tmp
@@ -107,6 +109,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp
+      - set_env_vars
       - run:
           command: |
             DEST_PATH=home/wpe-user/sites/<< parameters.sp_install >>/wp-content/uploads/member-access
@@ -124,6 +127,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp
+      - set_env_vars
       - run:
           name: "Copy Version to Latest"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,11 @@ commands:
       - run:
           name: "Set Theme Slug"
           command: |
-            echo "export THEME_SLUG=$(grep 'textdomain' /tmp/theme/package.json | awk -F: '{print $2}' | sed -e 's/\s//g' -e 's/[\"\,]//g')" >> ${BASH_ENV}
+            echo "export THEME_SLUG=$(grep 'textdomain":' /tmp/theme/package.json | awk -F: '{print $2}' | sed -e 's/\s//g' -e 's/[\"\,]//g')" >> ${BASH_ENV}
       - run:
           name: "Set Theme Version"
           command: |
-            echo "export THEME_VERSION=$(grep 'version' /tmp/theme/package.json | awk -F: '{print $2}' | sed -e 's/\s//g' -e 's/[\"\,]//g')" >> ${BASH_ENV}
+            echo "export THEME_VERSION=$(grep 'version":' /tmp/theme/package.json | awk -F: '{print $2}' | sed -e 's/\s//g' -e 's/[\"\,]//g')" >> ${BASH_ENV}
       - run:
           name: "Set Artifact Name"
           command: |
@@ -111,12 +111,13 @@ jobs:
           at: /tmp
       - set_env_vars
       - run:
+          name: Deploy To StudioPress
           command: |
             DEST_PATH=home/wpe-user/sites/<< parameters.sp_install >>/wp-content/uploads/member-access
             DEST_HOST=<< parameters.sp_install >>@<< parameters.sp_install >>.ssh.wpengine.net
             echo "${SP_DEPLOY_KEY}" | base64 -d > ./sp_deploy_key
             chmod 600 ./sp_deploy_key
-      - run: scp -i ./sp_deploy_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null /tmp/artifacts/${VERSION_ARTIFACT_FILE} ${DEST_HOST}:/${DEST_PATH}
+            scp -i ./sp_deploy_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null /tmp/artifacts/${VERSION_ARTIFACT_FILE} ${DEST_HOST}:/${DEST_PATH}
 
   deploy_s3:
     executor: python


### PR DESCRIPTION
This PR fixes the bug with the `deploy_studiopress` job. I had the required env vars being defined in a separate step. Because of this their values weren't being passed down the the actual `scp` work. I didn't want to persist the vars to `$BASH_ENV` like other environment variables as they are specific in scope to the SP deploy itself.

Tested fully in a separate branch