### PR TITLE
ci: quick adjustments to CircleCI Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp
+      - set_env_vars
       - run: npm ci
       - run: npm run zip
       - mkdir_artifacts
@@ -92,6 +93,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp
+      - set_env_vars
       - run: npm run prep:piservice /tmp/artifacts
       - persist_to_workspace:
           root: /tmp
@@ -107,6 +109,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp
+      - set_env_vars
       - run:
           command: |
             DEST_PATH=home/wpe-user/sites/<< parameters.sp_install >>/wp-content/uploads/member-access
@@ -124,6 +127,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp
+      - set_env_vars
       - run:
           name: "Copy Version to Latest"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,11 @@ commands:
       - run:
           name: "Set Theme Slug"
           command: |
-            echo "export THEME_SLUG=$(grep 'textdomain' /tmp/theme/package.json | awk -F: '{print $2}' | sed -e 's/\s//g' -e 's/[\"\,]//g')" >> ${BASH_ENV}
+            echo "export THEME_SLUG=$(grep 'textdomain":' /tmp/theme/package.json | awk -F: '{print $2}' | sed -e 's/\s//g' -e 's/[\"\,]//g')" >> ${BASH_ENV}
       - run:
           name: "Set Theme Version"
           command: |
-            echo "export THEME_VERSION=$(grep 'version' /tmp/theme/package.json | awk -F: '{print $2}' | sed -e 's/\s//g' -e 's/[\"\,]//g')" >> ${BASH_ENV}
+            echo "export THEME_VERSION=$(grep 'version":' /tmp/theme/package.json | awk -F: '{print $2}' | sed -e 's/\s//g' -e 's/[\"\,]//g')" >> ${BASH_ENV}
       - run:
           name: "Set Artifact Name"
           command: |
@@ -111,12 +111,13 @@ jobs:
           at: /tmp
       - set_env_vars
       - run:
+          name: Deploy To StudioPress
           command: |
             DEST_PATH=home/wpe-user/sites/<< parameters.sp_install >>/wp-content/uploads/member-access
             DEST_HOST=<< parameters.sp_install >>@<< parameters.sp_install >>.ssh.wpengine.net
             echo "${SP_DEPLOY_KEY}" | base64 -d > ./sp_deploy_key
             chmod 600 ./sp_deploy_key
-      - run: scp -i ./sp_deploy_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null /tmp/artifacts/${VERSION_ARTIFACT_FILE} ${DEST_HOST}:/${DEST_PATH}
+            scp -i ./sp_deploy_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null /tmp/artifacts/${VERSION_ARTIFACT_FILE} ${DEST_HOST}:/${DEST_PATH}
 
   deploy_s3:
     executor: python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ workflows:
                 - master
       - deploy_s3:
           context: wpe-product-info-aws
-          # environment: staging/themes
+          environment: staging/themes
           requires:
             - create_data_file
             - deploy_studiopress

--- a/.scripts/makePIServiceData.js
+++ b/.scripts/makePIServiceData.js
@@ -29,9 +29,10 @@ const runScript = function() {
 	// Write data object to a JSON file
 	const themeName = process.env.THEME_SLUG || data.textdomain;
 	const themeVersion = process.env.THEME_VERSION || data.version;
-	const filePath = `${destPath}/${process.env.VERSION_DATA_FILE}` || `${destPath}/${themeName}.${themeVersion}.json`;
+	const fileName = process.env.VERSION_DATA_FILE || `${themeName}.${themeVersion}.json`;
+	const filePath = `${destPath}/${fileName}`;
+
 	fs.writeFileSync(filePath, JSON.stringify(data));
-}
 
 /**
  * Sanitize destination path


### PR DESCRIPTION
<!-- A short but detailed summary of the changes. -->
This PR is a quick adjustment to the CircleCI config to only allow the `branch_deploy` job to deploy artifacts to the staging S3 bucket.

It also has a small fix to the `makePIServiceData.js` script in the event that certain environment variables aren't set.
