### PR TITLE
Remove genesis-lazy-load-images support

### DIFF
--- a/config/theme-supports.php
+++ b/config/theme-supports.php
@@ -32,7 +32,6 @@ return [
 		'search-form',
 		'skip-links',
 	],
-	'genesis-lazy-load-images'        => '',
 	'genesis-after-entry-widget-area' => '',
 	'genesis-footer-widgets'          => 3,
 	'genesis-menus'                   => [


### PR DESCRIPTION
<!-- A short but detailed summary of the changes. -->

Removes `genesis-lazy-load-images` theme support in preparation for WordPress 5.5's lazy loading feature.

### How to test
<!-- Detailed steps to test this PR. -->

1. Install a RC version of WP 5.5.
2. Visit an archive page that displays images and make sure loading="lazy" is present.

### Documentation
No documentation required. 
<!-- Documentation required. See #xxx. -->
<!-- PR includes documentation. -->

### Suggested changelog entry
<!-- A short description for the changelog. -->
- Removed: `genesis-lazy-load-images` theme support in preparation for WordPress 5.5's lazy loading feature.

### Notes
<!-- Additional information for reviewers. -->
