### PR TITLE
Add navigation-widgets HTML5 theme support

### DIFF
--- a/config/theme-supports.php
+++ b/config/theme-supports.php
@@ -22,6 +22,7 @@ return [
 		'comment-form',
 		'comment-list',
 		'gallery',
+		'navigation-widgets',
 		'search-form',
 		'script',
 		'style',


### PR DESCRIPTION
Add [navigation-widgets](https://make.wordpress.org/core/2020/07/09/accessibility-improvements-to-widgets-outputting-lists-of-links-in-5-5/) HTML5 theme support

### How to test
<!-- Detailed steps to test this PR. -->
1. Use WP 5.5
2. Add a navigation widget with a title and an archive widget or any from the list below.
3. Make sure an aria-label is present for the widget and navigation is wrapped in a `<nav>` element. It will use the widget title.

Widgets
- Navigation menu
- Archives
- Categories
- Pages
- Recent posts
- Recent comments
- Meta
- RSS

### Documentation
No documentation required.
<!-- Documentation required. See #xxx. -->
<!-- PR includes documentation. -->

### Suggested changelog entry
<!-- A short description for the changelog. -->
- Added: WordPress 5.5 `navigation-widgets` HTML5 theme support declaration.

### Notes
<!-- Additional information for reviewers. -->
