### PR TITLE
Fix .menu-toggle transition

### DIFF
--- a/style.css
+++ b/style.css
@@ -1169,6 +1169,10 @@ figcaption,
 	content: "\f335";
 }
 
+.site-header .dashicons-before::before {
+	transition: none;
+}
+
 .site-header .menu-toggle::before {
 	float: left;
 	margin-right: 5px;


### PR DESCRIPTION
<!-- A short but detailed summary of the changes. -->

Fixes a minor issue where the transition for the hamburger was not the same as for the `Menu` button text.



### How to test
<!-- Detailed steps to test this PR. -->
1. Narrow the browser or use a mobile phone to show the mobile menu.
2. On desktop, hover over the hamburger menu. On mobile, tap the button so the menu opens.
3. Transitions should be the same for the icon and the text.

### Documentation
No documentation required.
<!-- Documentation required. See #xxx. -->
<!-- PR includes documentation. -->

### Suggested changelog entry
<!-- A short description for the changelog. -->
- Fixed: Hamburger button icon CSS transition.

### Notes
<!-- Additional information for reviewers. -->

It's really easier to see the problem on desktop hover, but is also present on devices.
