### PR TITLE
Improve CLS caused by mobile menu

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -91,6 +91,49 @@ function genesis_sample_enqueue_scripts_styles() {
 
 }
 
+add_filter( 'body_class', 'genesis_sample_body_classes' );
+/**
+ * Add additional classes to the body element.
+ *
+ * @since 3.4.1
+ *
+ * @param array $classes Classes array.
+ * @return array $classes Updated class array.
+ */
+function genesis_sample_body_classes( $classes ) {
+
+	if ( ! genesis_is_amp() ) {
+		// Add 'no-js' class to the body class values.
+		$classes[] = 'no-js';
+	}
+	return $classes;
+}
+
+add_action( 'genesis_before', 'genesis_sample_js_nojs_script', 1 );
+/**
+ * Echo the script that changes 'no-js' class to 'js'.
+ *
+ * @since 3.4.1
+ */
+function genesis_sample_js_nojs_script() {
+
+	if ( genesis_is_amp() ) {
+		return;
+	}
+
+	?>
+	<script>
+	//<![CDATA[
+	(function(){
+		var c = document.body.classList;
+		c.remove( 'no-js' );
+		c.add( 'js' );
+	})();
+	//]]>
+	</script>
+	<?php
+}
+
 add_action( 'after_setup_theme', 'genesis_sample_theme_support', 9 );
 /**
  * Add desired theme supports.
@@ -142,17 +185,17 @@ genesis_unregister_layout( 'content-sidebar-sidebar' );
 genesis_unregister_layout( 'sidebar-content-sidebar' );
 genesis_unregister_layout( 'sidebar-sidebar-content' );
 
-// Repositions primary navigation menu.
+// Repositions primary genesis_sample menu.
 remove_action( 'genesis_after_header', 'genesis_do_nav' );
 add_action( 'genesis_header', 'genesis_do_nav', 12 );
 
-// Repositions the secondary navigation menu.
+// Repositions the secondary genesis_sample menu.
 remove_action( 'genesis_after_header', 'genesis_do_subnav' );
 add_action( 'genesis_footer', 'genesis_do_subnav', 10 );
 
 add_filter( 'wp_nav_menu_args', 'genesis_sample_secondary_menu_args' );
 /**
- * Reduces secondary navigation menu to one level depth.
+ * Reduces secondary genesis_sample menu to one level depth.
  *
  * @since 2.2.3
  *

--- a/lib/output.php
+++ b/lib/output.php
@@ -104,6 +104,18 @@ function genesis_sample_css() {
 		'
 	: '';
 
+	if ( ! is_customize_preview() ) {
+		$css .= has_custom_logo() ? sprintf(
+			'
+		.wp-custom-logo .site-container .custom-logo-link {
+			aspect-ratio: %1$s/%2$s;
+		}
+		',
+			$logo_max_width,
+			$logo_effective_height
+		) : '';
+	}
+
 	$css .= ( has_custom_logo() && ( 350 !== $logo_max_width ) ) ? sprintf(
 		'
 		.wp-custom-logo .site-container .title-area {

--- a/style.css
+++ b/style.css
@@ -1125,7 +1125,7 @@ figcaption,
 	opacity: 1;
 }
 
-.genesis-responsive-menu {
+.js .nav-primary {
 	display: none;
 	position: relative;
 }
@@ -1541,7 +1541,7 @@ p.entry-meta {
 	/* Responsive Menu
 	--------------------------------------------- */
 
-	.genesis-responsive-menu {
+	.js .nav-primary {
 		display: block;
 		padding-top: 15px;
 	}

--- a/style.css
+++ b/style.css
@@ -1013,6 +1013,10 @@ figcaption,
 	width: 100%;
 }
 
+.wp-custom-logo .custom-logo-link {
+	display: block;
+}
+
 .wp-custom-logo .title-area img {
 	width: auto;
 }


### PR DESCRIPTION
<!-- A short but detailed summary of the changes. -->

Implements no-js/js solution to prevent Content Layout Shift (CLS) caused by the mobile menu.

Closes #307

### How to test
<!-- Detailed steps to test this PR. -->
1. Test with Genesis 3.3.3 and this branch. It will be helpful to have a live site for testing.
2. Set up a multi-level menu.
3. Run some tests with Chrome dev tools, https://developers.google.com/speed/pagespeed/insights/ and https://web.dev/measure/

### Documentation
No documentation required.

### Suggested changelog entry
<!-- A short description for the changelog. -->
- Fixed: Content Layout Shift (CLS) caused by the mobile menu.

### Notes
<!-- Additional information for reviewers. -->

Also tested with AMP enabled.