### PR TITLE
Fix/logo cls

### DIFF
--- a/lib/output.php
+++ b/lib/output.php
@@ -111,7 +111,7 @@ function genesis_sample_css() {
 			aspect-ratio: %1$s/%2$s;
 		}
 		',
-			strip_tags( $logo_max_width ),
+			$logo_max_width,
 			$logo_effective_height
 		) : '';
 	}

--- a/lib/output.php
+++ b/lib/output.php
@@ -104,6 +104,16 @@ function genesis_sample_css() {
 		'
 	: '';
 
+	$css .= ( has_custom_logo() ) ? sprintf(
+		'
+		.wp-custom-logo .site-container .custom-logo-link {
+			aspect-ratio: %1$s/%2$s;
+		}
+		',
+		min( $logo_width, $logo_max_width ),
+		$logo_effective_height
+	) : '';
+
 	$css .= ( has_custom_logo() && ( 350 !== $logo_max_width ) ) ? sprintf(
 		'
 		.wp-custom-logo .site-container .title-area {

--- a/lib/output.php
+++ b/lib/output.php
@@ -111,7 +111,7 @@ function genesis_sample_css() {
 			aspect-ratio: %1$s/%2$s;
 		}
 		',
-			$logo_max_width,
+			strip_tags( $logo_max_width ),
 			$logo_effective_height
 		) : '';
 	}

--- a/lib/output.php
+++ b/lib/output.php
@@ -104,15 +104,17 @@ function genesis_sample_css() {
 		'
 	: '';
 
-	$css .= ( has_custom_logo() ) ? sprintf(
-		'
+	if ( ! is_customize_preview() ) {
+		$css .= ( has_custom_logo() ) ? sprintf(
+			'
 		.wp-custom-logo .site-container .custom-logo-link {
 			aspect-ratio: %1$s/%2$s;
 		}
 		',
-		min( $logo_width, $logo_max_width ),
-		$logo_effective_height
-	) : '';
+			$logo_max_width,
+			$logo_effective_height
+		) : '';
+	}
 
 	$css .= ( has_custom_logo() && ( 350 !== $logo_max_width ) ) ? sprintf(
 		'

--- a/lib/output.php
+++ b/lib/output.php
@@ -105,7 +105,7 @@ function genesis_sample_css() {
 	: '';
 
 	if ( ! is_customize_preview() ) {
-		$css .= ( has_custom_logo() ) ? sprintf(
+		$css .= has_custom_logo() ? sprintf(
 			'
 		.wp-custom-logo .site-container .custom-logo-link {
 			aspect-ratio: %1$s/%2$s;

--- a/style.css
+++ b/style.css
@@ -1013,6 +1013,10 @@ figcaption,
 	width: 100%;
 }
 
+.wp-custom-logo .custom-logo-link {
+	display: block;
+}
+
 .wp-custom-logo .title-area img {
 	width: auto;
 }


### PR DESCRIPTION
<!-- A short but detailed summary of the changes. -->

CLS occurs when a custom logo is set. Since the logo height is variable, there may be more or less impact on CLS.

This PR uses [aspect ratio](https://web.dev/aspect-ratio/) to reserve the logo space.

### How to test
<!-- Detailed steps to test this PR. -->
1. Use Genesis 3.3.3 and this branch.
2. Under Appearance > Customize > Site Identity, upload a logo.
3. Adjust the _Logo Width_ as desired.
4. Close the customizer and run some tests with Chrome dev tools, https://developers.google.com/speed/pagespeed/insights/ and https://web.dev/measure/
5. Adjust the _Logo Width_ a few times to make sure the logo size looks correct on the front end. Note that the aspect ratio is not added in the customizer.
6. Repeat with logos of varying sizes.

### Documentation
No documentation required.
<!-- Documentation required. See #xxx. -->
<!-- PR includes documentation. -->

### Suggested changelog entry
<!-- A short description for the changelog. -->
- Fixed: Content Layout Shift (CLS) when using a custom logo.

### Notes
<!-- Additional information for reviewers. -->
- This PR is based on and set to merge into #371.