### PR TITLE
Make version null to prevent removal of any duplicate font families

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -75,7 +75,7 @@ function genesis_sample_enqueue_scripts_styles() {
 		genesis_get_theme_handle() . '-fonts',
 		$appearance['fonts-url'],
 		[],
-		genesis_get_theme_version()
+		null
 	);
 
 	wp_enqueue_style( 'dashicons' );

--- a/functions.php
+++ b/functions.php
@@ -71,7 +71,7 @@ function genesis_sample_enqueue_scripts_styles() {
 
 	$appearance = genesis_get_config( 'appearance' );
 
-	wp_enqueue_style(
+	wp_enqueue_style( // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion -- see https://core.trac.wordpress.org/ticket/49742
 		genesis_get_theme_handle() . '-fonts',
 		$appearance['fonts-url'],
 		[],


### PR DESCRIPTION
<!-- A short but detailed summary of the changes. -->

Replaces #346 to include phpcs: ignore.

### How to test
<!-- Detailed steps to test this PR. -->
1. Change fonts-url in config/appearance to https://fonts.googleapis.com/css2?family=Alex+Brush&family=Open+Sans:wght@400;700;800&display=swap
2. Load page & check the output link tag for id="genesis-sample-fonts-css"

### Documentation
<!-- No documentation required. -->
<!-- Documentation required. See #xxx. -->
<!-- PR includes documentation. -->

### Suggested changelog entry
<!-- A short description for the changelog. -->
- Changed: Use `null` in place of theme version for Google Fonts URL.

### Notes
<!-- Additional information for reviewers. -->
