### PR TITLE
Update/dependencies

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,5 +1,5 @@
 {
-	"extends": "stylelint-config-wordpress",
+	"extends": "@wordpress/stylelint-config",
 	"rules": {
 		"no-descending-specificity": null,
 		"no-duplicate-selectors": null,

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 	},
 	"require-dev": {
 		"php": "^5.6 || ^7",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
 		"phpcompatibility/phpcompatibility-wp": "^2",
 		"squizlabs/php_codesniffer": "^3.3.2",
 		"wp-coding-standards/wpcs": "^1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -363,6 +363,17 @@
 			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
 			"dev": true
 		},
+		"@wordpress/stylelint-config": {
+			"version": "19.0.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-19.0.1.tgz",
+			"integrity": "sha512-CrYX64Oj2vwrVcTOEu8KYdgD5VPspG+EmJYO8zLQoyTHSFp1XAEdAMKBotKcEAzoTPlT44lD3ch55rT1pUkG+A==",
+			"dev": true,
+			"requires": {
+				"stylelint-config-recommended": "^3.0.0",
+				"stylelint-config-recommended-scss": "^4.2.0",
+				"stylelint-scss": "^3.17.2"
+			}
+		},
 		"acorn": {
 			"version": "6.4.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
@@ -3826,17 +3837,6 @@
 			"dev": true,
 			"requires": {
 				"stylelint-config-recommended": "^3.0.0"
-			}
-		},
-		"stylelint-config-wordpress": {
-			"version": "17.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-wordpress/-/stylelint-config-wordpress-17.0.0.tgz",
-			"integrity": "sha512-qUU2kVMd2ezIV9AzRdgietIfnavRRENt4180A1OMoVXIowRjjhohZgBiyVPV5EtNKo3GTO63l8g/QGNG27/h9g==",
-			"dev": true,
-			"requires": {
-				"stylelint-config-recommended": "^3.0.0",
-				"stylelint-config-recommended-scss": "^4.2.0",
-				"stylelint-scss": "^3.17.2"
 			}
 		},
 		"stylelint-scss": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 	},
 	"license": "GPL-2.0-or-later",
 	"devDependencies": {
+		"@wordpress/stylelint-config": "^19.0.1",
 		"archiver": "^3.1.1",
 		"autoprefixer": "^9.8.6",
 		"chalk": "^2.4.2",
@@ -18,8 +19,7 @@
 		"postcss-cli": "^8.2.0",
 		"pretty-bytes": "^5.4.1",
 		"recursive-readdir": "^2.2.2",
-		"stylelint": "^13.7.2",
-		"stylelint-config-wordpress": "^17.0.0"
+		"stylelint": "^13.7.2"
 	},
 	"scripts": {
 		"autoprefixer": "postcss style.css lib/**/*.css --use autoprefixer --replace --no-map --verbose",


### PR DESCRIPTION
<!-- A short but detailed summary of the changes. -->

Replaces `stylelint-config-wordpress` with `@wordpress/stylelint-config`.
Updates `dealerdirect/phpcodesniffer-composer-installer` to ^0.7.1 to fix #369 

### How to test
<!-- Detailed steps to test this PR. -->
1. Run `composer install` and `npm install`.
2. Make sure `npm run lint:css` works (Ran in Circle fine)

