### PR TITLE
Missing comma in WooCommerce CSS file

### DIFF
--- a/lib/woocommerce/genesis-sample-woocommerce.css
+++ b/lib/woocommerce/genesis-sample-woocommerce.css
@@ -840,7 +840,7 @@ div.woocommerce-info.wc-memberships-restriction-message.wc-memberships-restricte
 
 @media only screen and (min-width: 860px) {
 
-	.full-width-content .woocommerce ul.products
+	.full-width-content .woocommerce ul.products,
 	.full-width-content.woocommerce ul.products {
 		justify-content: flex-start;
 	}


### PR DESCRIPTION
Reported here: https://genesiswp.slack.com/archives/CD7D7QAG0/p1634543179001600

### Documentation
No documentation required.

### Suggested changelog entry
- Fix: missing comma in WooCommerce CSS file
