### PR TITLE
Fix WPForms form creation

### DIFF
--- a/lib/wpforms.php
+++ b/lib/wpforms.php
@@ -55,8 +55,7 @@ function studiopress_maybe_create_wpforms_form() { // phpcs:ignore -- studiopres
 		esc_html__( 'Simple Contact Form', 'genesis-sample' ),
 		[],
 		[
-			'template' => 'contact',
-			'builder'  => false,
+			'template' => 'simple-contact-form-template',
 		]
 	);
 

--- a/lib/wpforms.php
+++ b/lib/wpforms.php
@@ -24,14 +24,14 @@ function studiopress_maybe_create_wpforms_form() { // phpcs:ignore -- studiopres
 		return;
 	}
 
-	// Form creation requires WPForms 1.5.2 or higher.
+	// Form creation requires WPForms 1.6.8 or higher.
 	// If the site already as an earlier version of the plugin installed, don't create a form.
 	// Plugins do not get upgraded during one-click theme setup.
 	if ( function_exists( 'get_plugins' ) ) {
 		$plugin_data          = get_plugins();
 		$wpforms_lite_version = isset( $plugin_data['wpforms-lite/wpforms.php']['Version'] ) ? $plugin_data['wpforms-lite/wpforms.php']['Version'] : '';
 
-		if ( version_compare( $wpforms_lite_version, '1.5.2', '<' ) ) {
+		if ( version_compare( $wpforms_lite_version, '1.6.8', '<' ) ) {
 			return;
 		}
 	}
@@ -50,7 +50,7 @@ function studiopress_maybe_create_wpforms_form() { // phpcs:ignore -- studiopres
 		delete_option( 'genesis_onboarding_wpforms_id' );
 	}
 
-	// Creates a form using the WPForms 'contact' template.
+	// Creates a form using the WPForms 'simple-contact-form-template' template.
 	$new_form_id = wpforms()->form->add(
 		esc_html__( 'Simple Contact Form', 'genesis-sample' ),
 		[],

--- a/lib/wpforms.php
+++ b/lib/wpforms.php
@@ -24,14 +24,14 @@ function studiopress_maybe_create_wpforms_form() { // phpcs:ignore -- studiopres
 		return;
 	}
 
-	// Form creation requires WPForms 1.6.8 or higher.
+	// Form creation requires WPForms 1.7.6 or higher.
 	// If the site already as an earlier version of the plugin installed, don't create a form.
 	// Plugins do not get upgraded during one-click theme setup.
 	if ( function_exists( 'get_plugins' ) ) {
 		$plugin_data          = get_plugins();
 		$wpforms_lite_version = isset( $plugin_data['wpforms-lite/wpforms.php']['Version'] ) ? $plugin_data['wpforms-lite/wpforms.php']['Version'] : '';
 
-		if ( version_compare( $wpforms_lite_version, '1.6.8', '<' ) ) {
+		if ( version_compare( $wpforms_lite_version, '1.7.6', '<' ) ) {
 			return;
 		}
 	}
@@ -56,6 +56,7 @@ function studiopress_maybe_create_wpforms_form() { // phpcs:ignore -- studiopres
 		[],
 		[
 			'template' => 'simple-contact-form-template',
+			'builder'  => false,
 		]
 	);
 


### PR DESCRIPTION
<!-- A short but detailed summary of the changes. -->

Fixes the OCTS _Contact Us_  form creation.

### How to test
<!-- Detailed steps to test this PR. -->
1. Using this branch on a fresh site, go to Genesis > Child Theme Setup and run your choice of OCTS.
2. Make sure that:
    - [ ] Form is created under WPForms > All Forms
    - [ ] Form contains fields
    - [ ] Form displays fields on the `contact-us` page.

### Documentation
No documentation required.


### Suggested changelog entry
<!-- A short description for the changelog. -->
- Fixed: One-click theme setup WPForms contact form creation.

### Notes
<!-- Additional information for reviewers. -->
