### PR TITLE
Fix genesis_sample_color_brightness()

### DIFF
--- a/lib/helper-functions.php
+++ b/lib/helper-functions.php
@@ -53,6 +53,6 @@ function genesis_sample_color_brightness( $color, $change ) {
 	$green = max( 0, min( 255, $green + $change ) );
 	$blue  = max( 0, min( 255, $blue + $change ) );
 
-	return '#' . dechex( $red ) . dechex( $green ) . dechex( $blue );
+	return sprintf( '#%02x%02x%02x', $red, $green, $blue );
 
 }


### PR DESCRIPTION
genesis_sample_color_brightness() produces invalid hex color codes given certain inputs.

genesis_sample_color_brightness( '#ff00ff' , 5 );

Expected: #ff05ff
Actual #ff5ff

### How to test
1. `echo genesis_sample_color_brightness( '#ff00ff' , 5 );`
2. Verify output

### Documentation
No documentation required.

### Suggested changelog entry
- Fix genesis_sample_color_brightness()