### PR TITLE
Remove Simple Social Icons and Genesis eNews from OCTS

### DIFF
--- a/config/onboarding-shared.php
+++ b/config/onboarding-shared.php
@@ -21,16 +21,6 @@ return [
 			'public_url' => 'https://wordpress.org/plugins/genesis-blocks/',
 		],
 		[
-			'name'       => __( 'Simple Social Icons', 'genesis-sample' ),
-			'slug'       => 'simple-social-icons/simple-social-icons.php',
-			'public_url' => 'https://wordpress.org/plugins/simple-social-icons/',
-		],
-		[
-			'name'       => __( 'Genesis eNews Extended (Third Party)', 'genesis-sample' ),
-			'slug'       => 'genesis-enews-extended/plugin.php',
-			'public_url' => 'https://wordpress.org/plugins/genesis-enews-extended/',
-		],
-		[
 			'name'       => __( 'WPForms Lite (Third Party)', 'genesis-sample' ),
 			'slug'       => 'wpforms-lite/wpforms.php',
 			'public_url' => 'https://wordpress.org/plugins/wpforms-lite/',

--- a/languages/genesis-sample.pot
+++ b/languages/genesis-sample.pot
@@ -1,14 +1,14 @@
-# <!=Copyright (C) 2021 StudioPress
+# <!=Copyright (C) 2022 StudioPress
 # This file is distributed under the GPL-2.0-or-later.=!>
 msgid ""
 msgstr ""
 "Project-Id-Version: Genesis Sample 3.4.1\n"
 "Report-Msgid-Bugs-To: StudioPress <translations@studiopress.com>\n"
-"POT-Creation-Date: 2021-03-23 15:47:25+00:00\n"
+"POT-Creation-Date: 2022-11-03 19:45:36+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2021-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2022-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: en\n"
@@ -56,14 +56,6 @@ msgid "Genesis Blocks"
 msgstr ""
 
 #: config/onboarding-shared.php:24
-msgid "Simple Social Icons"
-msgstr ""
-
-#: config/onboarding-shared.php:29
-msgid "Genesis eNews Extended (Third Party)"
-msgstr ""
-
-#: config/onboarding-shared.php:34
 msgid "WPForms Lite (Third Party)"
 msgstr ""
 


### PR DESCRIPTION
Removes Simple Social Icons and Genesis eNews from OCTS.

### How to test
<!-- Detailed steps to test this PR. -->
1. Activate the theme and run OCTS.
2. Make sure the Simple Social Icons and Genesis eNews plugins aren't installed.

### Documentation
<!-- No documentation required. -->
Customer facing documentation updates may be required.
<!-- PR includes documentation. -->

### Suggested changelog entry
<!-- A short description for the changelog. -->

* Changed: Updated one-click-theme-setup to remove Genesis eNews Extended from plugin installation.

### Notes
<!-- Additional information for reviewers. -->
These are currently installed during OCTS, but not setup during OCTS.
