### PR TITLE
[LOC-6302] Defer registration of responsive menus

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -56,9 +56,19 @@ function genesis_child_gutenberg_support() { // phpcs:ignore WordPress.NamingCon
 	require_once get_stylesheet_directory() . '/lib/gutenberg/init.php';
 }
 
-// Registers the responsive menus.
-if ( function_exists( 'genesis_register_responsive_menus' ) ) {
-	genesis_register_responsive_menus( genesis_get_config( 'responsive-menus' ) );
+add_action( 'after_setup_theme', 'genesis_sample_register_responsive_menus' );
+/**
+ * Registers the responsive menus.
+ *
+ * @since 3.4.3 Moved from file root to prevent notices about using translations
+ * before the after_setup_theme hook under WP 6.7+.
+ */
+function genesis_sample_register_responsive_menus() {
+
+	if ( function_exists( 'genesis_register_responsive_menus' ) ) {
+		genesis_register_responsive_menus( genesis_get_config( 'responsive-menus' ) );
+	}
+
 }
 
 add_action( 'wp_enqueue_scripts', 'genesis_sample_enqueue_scripts_styles' );


### PR DESCRIPTION
To prevent a "doing it wrong" notice under WP 6.7 due to calling __() before after_setup_theme.

Defers loading of calls to `genesis_register_responsive_menus` that were resulting in the "doing it wrong" message, so that they load during `after_setup_theme` instead of before it, which WordPress 6.7 now forbids.

https://make.wordpress.org/core/2024/10/21/i18n-improvements-6-7/#Enhanced-support-for-only-using-PHP-translation-files

### How to test

Follow the steps in https://github.com/studiopress/genesis/pull/2730.

After checking out this PR as described there, verify that the Genesis Responsive Menu still appears on the frontend when you reduce your browser width:

![responsive menu still visible](https://github.com/user-attachments/assets/9f462544-637c-4617-9052-69be41ea29af)


### Reference
https://wpengine.atlassian.net/browse/LOC-6302
