### PR TITLE
chore: support PHP 8 with composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,18 +11,22 @@
 		}
 	],
 	"require": {
-		"php": "^5.2 || ^7",
+		"php": "^5.2 || ^7 || ^8",
 		"composer/installers": "^1"
 	},
 	"require-dev": {
-		"php": "^5.6 || ^7",
+		"php": "^5.6 || ^7 || ^8",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
 		"phpcompatibility/phpcompatibility-wp": "^2",
 		"squizlabs/php_codesniffer": "^3.3.2",
 		"wp-coding-standards/wpcs": "^1.1"
 	},
 	"config": {
-		"sort-order": true
+		"sort-order": true,
+		"allow-plugins": {
+			"composer/installers": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	},
 	"scripts": {
 		"install-codestandards": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",


### PR DESCRIPTION
Adjusts `composer.json` so that `composer install` does not fail with PHP 8, and composer plugins install without a manual prompt.

### Before

```txt
> composer install
No composer.lock file present. Updating dependencies to latest instead of installing from lock file. See https://getcomposer.org/install for more information.
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires php ^5.6 || ^7 but your php version (8.2.23) does not satisfy that requirement.
````

### After

```txt
> composer install                   
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Package operations: 7 installs, 0 updates, 0 removals
  - Installing composer/installers (v1.12.0): Extracting archive
  - Installing squizlabs/php_codesniffer (3.11.3): Extracting archive
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.7.2): Extracting archive
  - Installing phpcompatibility/php-compatibility (9.3.5): Extracting archive
  - Installing phpcompatibility/phpcompatibility-paragonie (1.3.3): Extracting archive
  - Installing phpcompatibility/phpcompatibility-wp (2.1.6): Extracting archive
  - Installing wp-coding-standards/wpcs (1.2.1): Extracting archive
Generating autoload files
4 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/php-compatibility,../../phpcompatibility/phpcompatibility-paragonie,../../phpcompatibility/phpcompatibility-wp,../../wp-coding-standards/wpcs
```

### Testing

After install, `composer run phpcs` and `composer run phpcbf` both run under PHP 8.

```
> composer run phpcs
> phpcs
........ 8 / 8 (100%)


Time: 563ms; Memory: 4MB

> composer run phpcbf
> phpcbf
........ 8 / 8 (100%)

No fixable errors were found

Time: 368ms; Memory: 4MB
```